### PR TITLE
[Feat] 월드컵 기능 구현

### DIFF
--- a/src/main/java/kr/or/ddit/config/SecurityConfig.java
+++ b/src/main/java/kr/or/ddit/config/SecurityConfig.java
@@ -15,7 +15,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.security.config.Customizer.withDefaults;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -36,19 +36,6 @@ public class SecurityConfig {
 		
 	}
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-        	.cors(withDefaults())
-            .authorizeHttpRequests(auth -> auth
-                .anyRequest().permitAll() // 모든 요청 허용
-            )
-            .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (개발용)
-            .formLogin(form -> form.disable()) // 로그인 폼 비활성화
-            .httpBasic(httpBasic -> httpBasic.disable()); // HTTP Basic 인증 비활성화
-
-        return http.build();
-    }
     
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
@@ -64,7 +51,9 @@ public class SecurityConfig {
     }
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeHttpRequests(auth -> auth
+		http
+				.cors(Customizer.withDefaults())
+				.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/test").hasRole("USER") // 모든 사용자는 유저권한을 포함시켜놨습니다. 로그인이 필요한 서비스는 여기에 넣어주시면 됩니다.
 				.anyRequest().permitAll()).csrf(csrf -> csrf.disable())
 				.exceptionHandling(ex -> ex

--- a/src/main/java/kr/or/ddit/config/SecurityConfig.java
+++ b/src/main/java/kr/or/ddit/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package kr.or.ddit.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -10,6 +12,10 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.security.config.Customizer.withDefaults;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -30,6 +36,32 @@ public class SecurityConfig {
 		
 	}
 
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+        	.cors(withDefaults())
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().permitAll() // 모든 요청 허용
+            )
+            .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (개발용)
+            .formLogin(form -> form.disable()) // 로그인 폼 비활성화
+            .httpBasic(httpBasic -> httpBasic.disable()); // HTTP Basic 인증 비활성화
+
+        return http.build();
+    }
+    
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:5173"));  // React dev 서버
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/worldcup/**", config);
+        return source;
+    }
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http.authorizeHttpRequests(auth -> auth

--- a/src/main/java/kr/or/ddit/worldcup/service/ComCodeVO.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/ComCodeVO.java
@@ -1,0 +1,15 @@
+package kr.or.ddit.worldcup.service;
+
+import java.util.Date;
+
+public class ComCodeVO {
+	private String ccId;
+	private String clCode;
+	private String ccName;
+	private String ccEtc;
+	private String useYn;
+	private Date createdAt;
+	private String createdBy;
+	private Date updatedAt;
+	private String updatedBy;
+}

--- a/src/main/java/kr/or/ddit/worldcup/service/ComCodeVO.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/ComCodeVO.java
@@ -2,6 +2,9 @@ package kr.or.ddit.worldcup.service;
 
 import java.util.Date;
 
+import lombok.Data;
+
+@Data
 public class ComCodeVO {
 	private String ccId;
 	private String clCode;

--- a/src/main/java/kr/or/ddit/worldcup/service/JobsVO.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/JobsVO.java
@@ -3,17 +3,27 @@ package kr.or.ddit.worldcup.service;
 import java.util.Date;
 
 public class JobsVO {
-	private int jobId;
 	private String jobCode;
 	private String jobName;
 	private String jobLcl;
 	private String jobMcl;
-	private int jobSal;
-	private String jobSatis;
-	private String jobProspect;
-	private String jobReqEdu;
+	private String jobSal;
+	private int jobSatis;
+	private String jobWay;
+	private String jobRelatedMajor;
 	private String jobRelatedCert;
 	private String jobMainDuty;
 	private Date jobCreatedAt;
 	private int fileGroupNo;
+	private int edubgMgraduUndr;
+	private int edubgHgradu;
+	private int edubgCgraduUndr;
+	private int edubgUgradu;
+	private int edubgGgradu;
+	private int edubgDgradu;
+	private int outlookIncrease;
+	private int outlookSlightIncrease;
+	private int outlookStable;
+	private int outlookSlightDecrease;
+	private int outlookDecrease;
 }

--- a/src/main/java/kr/or/ddit/worldcup/service/JobsVO.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/JobsVO.java
@@ -1,7 +1,11 @@
 package kr.or.ddit.worldcup.service;
 
 import java.util.Date;
+import java.util.List;
 
+import lombok.Data;
+
+@Data
 public class JobsVO {
 	private String jobCode;
 	private String jobName;
@@ -26,4 +30,6 @@ public class JobsVO {
 	private int outlookStable;
 	private int outlookSlightDecrease;
 	private int outlookDecrease;
+	
+	private List<String> jobsRel;
 }

--- a/src/main/java/kr/or/ddit/worldcup/service/JobsVO.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/JobsVO.java
@@ -1,0 +1,19 @@
+package kr.or.ddit.worldcup.service;
+
+import java.util.Date;
+
+public class JobsVO {
+	private int jobId;
+	private String jobCode;
+	private String jobName;
+	private String jobLcl;
+	private String jobMcl;
+	private int jobSal;
+	private String jobSatis;
+	private String jobProspect;
+	private String jobReqEdu;
+	private String jobRelatedCert;
+	private String jobMainDuty;
+	private Date jobCreatedAt;
+	private int fileGroupNo;
+}

--- a/src/main/java/kr/or/ddit/worldcup/service/WorldCupService.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/WorldCupService.java
@@ -10,5 +10,5 @@ public interface WorldCupService {
 
 	public JobsVO selectJobById(JobsVO jobsVO);
 
-	public int insertWorldcupResult(WorldCupVO worldCupVO);
+	public int insertWorldcupResult(JobsVO jobsVO,int id);
 }

--- a/src/main/java/kr/or/ddit/worldcup/service/WorldCupService.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/WorldCupService.java
@@ -1,0 +1,14 @@
+package kr.or.ddit.worldcup.service;
+
+import java.util.List;
+
+public interface WorldCupService {
+
+	public List<ComCodeVO> selectCategories(String round);
+
+	public List<JobsVO> selectJobsByCategory(ComCodeVO comCodeVO);
+
+	public JobsVO selectJobById(JobsVO jobsVO);
+
+	public int insertWorldcupResult(WorldCupVO worldCupVO);
+}

--- a/src/main/java/kr/or/ddit/worldcup/service/WorldCupService.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/WorldCupService.java
@@ -11,4 +11,6 @@ public interface WorldCupService {
 	public JobsVO selectJobById(JobsVO jobsVO);
 
 	public int insertWorldcupResult(JobsVO jobsVO,int id);
+
+	public ComCodeVO selectComCodeNameByccId(ComCodeVO comCodeVO);
 }

--- a/src/main/java/kr/or/ddit/worldcup/service/WorldCupVO.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/WorldCupVO.java
@@ -2,6 +2,9 @@ package kr.or.ddit.worldcup.service;
 
 import java.util.Date;
 
+import lombok.Data;
+
+@Data
 public class WorldCupVO {
 	private int wdId;
 	private int wdResult;

--- a/src/main/java/kr/or/ddit/worldcup/service/WorldCupVO.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/WorldCupVO.java
@@ -1,0 +1,10 @@
+package kr.or.ddit.worldcup.service;
+
+import java.util.Date;
+
+public class WorldCupVO {
+	private int wdId;
+	private int wdResult;
+	private Date createdAt;
+	private int memId;
+}

--- a/src/main/java/kr/or/ddit/worldcup/service/WorldCupVO.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/WorldCupVO.java
@@ -7,7 +7,7 @@ import lombok.Data;
 @Data
 public class WorldCupVO {
 	private int wdId;
-	private int wdResult;
+	private String wdResult;
 	private Date createdAt;
 	private int memId;
 }

--- a/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupMapper.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupMapper.java
@@ -1,0 +1,21 @@
+package kr.or.ddit.worldcup.service.impl;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import kr.or.ddit.worldcup.service.ComCodeVO;
+import kr.or.ddit.worldcup.service.JobsVO;
+import kr.or.ddit.worldcup.service.WorldCupVO;
+
+@Mapper
+public interface WorldCupMapper {
+	
+	public List<ComCodeVO> selectCategories(String round);
+
+	public List<JobsVO> selectJobsByCategory(ComCodeVO comCodeVO);
+
+	public JobsVO selectJobById(JobsVO jobsVO);
+
+	public int insertWorldcupResult(WorldCupVO worldCupVO);
+}

--- a/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupMapper.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupMapper.java
@@ -20,4 +20,6 @@ public interface WorldCupMapper {
 	public int insertWorldcupResult(WorldCupVO worldCupVO);
 	
 	public List<String> selectRelatedJobNames(JobsVO jobsVO);
+
+	public ComCodeVO selectComCodeNameByccId(ComCodeVO comCodeVO);
 }

--- a/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupMapper.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupMapper.java
@@ -18,4 +18,6 @@ public interface WorldCupMapper {
 	public JobsVO selectJobById(JobsVO jobsVO);
 
 	public int insertWorldcupResult(WorldCupVO worldCupVO);
+	
+	public List<String> selectRelatedJobNames(JobsVO jobsVO);
 }

--- a/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupServiceImpl.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupServiceImpl.java
@@ -30,8 +30,11 @@ public class WorldCupServiceImpl implements WorldCupService {
 
 	@Override
 	public JobsVO selectJobById(JobsVO jobsVO) {
-		// TODO Auto-generated method stub
-		return worldCupMapper.selectJobById(jobsVO);
+		
+		jobsVO = worldCupMapper.selectJobById(jobsVO);
+		List<String> relatedJobs = worldCupMapper.selectRelatedJobNames(jobsVO);
+		jobsVO.setJobsRel(relatedJobs);
+		return jobsVO;
 	}
 
 	@Override
@@ -39,5 +42,4 @@ public class WorldCupServiceImpl implements WorldCupService {
 		// TODO Auto-generated method stub
 		return worldCupMapper.insertWorldcupResult(worldCupVO);
 	}
-
 }

--- a/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupServiceImpl.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupServiceImpl.java
@@ -46,4 +46,10 @@ public class WorldCupServiceImpl implements WorldCupService {
 		
 		return worldCupMapper.insertWorldcupResult(worldCupVO);
 	}
+
+	@Override
+	public ComCodeVO selectComCodeNameByccId(ComCodeVO comCodeVO) {
+		// TODO Auto-generated method stub
+		return worldCupMapper.selectComCodeNameByccId(comCodeVO);
+	}
 }

--- a/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupServiceImpl.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupServiceImpl.java
@@ -38,8 +38,12 @@ public class WorldCupServiceImpl implements WorldCupService {
 	}
 
 	@Override
-	public int insertWorldcupResult(WorldCupVO worldCupVO) {
-		// TODO Auto-generated method stub
+	public int insertWorldcupResult(JobsVO jobsVO,int id) {
+		
+		WorldCupVO worldCupVO= new WorldCupVO();
+		worldCupVO.setMemId(id);
+		worldCupVO.setWdResult(jobsVO.getJobCode());
+		
 		return worldCupMapper.insertWorldcupResult(worldCupVO);
 	}
 }

--- a/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupServiceImpl.java
+++ b/src/main/java/kr/or/ddit/worldcup/service/impl/WorldCupServiceImpl.java
@@ -1,0 +1,43 @@
+package kr.or.ddit.worldcup.service.impl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import kr.or.ddit.worldcup.service.ComCodeVO;
+import kr.or.ddit.worldcup.service.JobsVO;
+import kr.or.ddit.worldcup.service.WorldCupService;
+import kr.or.ddit.worldcup.service.WorldCupVO;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class WorldCupServiceImpl implements WorldCupService {
+
+	private final WorldCupMapper worldCupMapper;
+
+	@Override
+	public List<ComCodeVO> selectCategories(String round) {
+		// TODO Auto-generated method stub
+		return worldCupMapper.selectCategories(round);
+	}
+
+	@Override
+	public List<JobsVO> selectJobsByCategory(ComCodeVO comCodeVO) {
+		// TODO Auto-generated method stub
+		return worldCupMapper.selectJobsByCategory(comCodeVO);
+	}
+
+	@Override
+	public JobsVO selectJobById(JobsVO jobsVO) {
+		// TODO Auto-generated method stub
+		return worldCupMapper.selectJobById(jobsVO);
+	}
+
+	@Override
+	public int insertWorldcupResult(WorldCupVO worldCupVO) {
+		// TODO Auto-generated method stub
+		return worldCupMapper.insertWorldcupResult(worldCupVO);
+	}
+
+}

--- a/src/main/java/kr/or/ddit/worldcup/web/WorldCupController.java
+++ b/src/main/java/kr/or/ddit/worldcup/web/WorldCupController.java
@@ -1,9 +1,16 @@
 package kr.or.ddit.worldcup.web;
 
+import java.util.List;
+
+import org.apache.ibatis.annotations.Param;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import kr.or.ddit.worldcup.service.ComCodeVO;
 import kr.or.ddit.worldcup.service.WorldCupService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,11 +18,18 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/wouldcup")
+@RequestMapping("/worldcup")
 public class WorldCupController {
 
 	private final WorldCupService worldCupService;
 	
+	@GetMapping("/selectCategories")
+	public ResponseEntity<List<ComCodeVO>> selectCategories(@RequestParam String round){
+		List<ComCodeVO> comCodeVOList = worldCupService.selectCategories(round);
+		log.info("WorldCupController - > selectCategories : "+comCodeVOList);
+		return ResponseEntity.ok(comCodeVOList);
+		
+	}
 	
 	
 }

--- a/src/main/java/kr/or/ddit/worldcup/web/WorldCupController.java
+++ b/src/main/java/kr/or/ddit/worldcup/web/WorldCupController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Param;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import kr.or.ddit.worldcup.service.ComCodeVO;
 import kr.or.ddit.worldcup.service.JobsVO;
 import kr.or.ddit.worldcup.service.WorldCupService;
+import kr.or.ddit.worldcup.service.WorldCupVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -53,14 +55,17 @@ public class WorldCupController {
 
 	}
 	
-//	@PostMapping("/insertWorldcupResult")
-//	public ResponseEntity<int> insertWorldcupResult(@RequestBody JobsVO jobsVO) {
-//
-//		int cnt = worldCupService.insertWorldcupResult(jobsVO);
-//		
-//		return ResponseEntity.ok();
-//
-//	}
+	@PostMapping("/insertWorldcupResult")
+	public ResponseEntity<Integer> insertWorldcupResult(@AuthenticationPrincipal String memId,@RequestBody JobsVO jobsVO) {
+
+		int id = Integer.valueOf(memId);
+		
+		int cnt = worldCupService.insertWorldcupResult(jobsVO,id);
+		
+		log.info("cnt : "+cnt);
+		return (ResponseEntity<Integer>) ResponseEntity.ok();
+
+	}
 	
 	
 	

--- a/src/main/java/kr/or/ddit/worldcup/web/WorldCupController.java
+++ b/src/main/java/kr/or/ddit/worldcup/web/WorldCupController.java
@@ -6,11 +6,14 @@ import org.apache.ibatis.annotations.Param;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import kr.or.ddit.worldcup.service.ComCodeVO;
+import kr.or.ddit.worldcup.service.JobsVO;
 import kr.or.ddit.worldcup.service.WorldCupService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,12 +27,41 @@ public class WorldCupController {
 	private final WorldCupService worldCupService;
 	
 	@GetMapping("/selectCategories")
-	public ResponseEntity<List<ComCodeVO>> selectCategories(@RequestParam String round){
+	public ResponseEntity<List<ComCodeVO>> selectCategories(@RequestParam String round) {
 		List<ComCodeVO> comCodeVOList = worldCupService.selectCategories(round);
-		log.info("WorldCupController - > selectCategories : "+comCodeVOList);
+		log.info("WorldCupController - > selectCategories : " + comCodeVOList);
 		return ResponseEntity.ok(comCodeVOList);
-		
+
 	}
+
+	@PostMapping("/selectJobsByCategory")
+	public ResponseEntity<List<JobsVO>> selectJobsByCategory(@RequestBody ComCodeVO comCodeVO) {
+		log.info("WorldCupController -> comCodeVO :" + comCodeVO);
+		List<JobsVO> jobsVOList = worldCupService.selectJobsByCategory(comCodeVO);
+		log.info("WorldCupController -> jobsVOList :" + jobsVOList);
+
+		return ResponseEntity.ok(jobsVOList);
+
+	}
+	
+	@PostMapping("/selectJobById")
+	public ResponseEntity<JobsVO> selectJobById(@RequestBody JobsVO jobsVO) {
+		jobsVO = worldCupService.selectJobById(jobsVO);
+		log.info("selectJobById -> jobsVO :" + jobsVO);
+		
+		return ResponseEntity.ok(jobsVO);
+
+	}
+	
+//	@PostMapping("/insertWorldcupResult")
+//	public ResponseEntity<int> insertWorldcupResult(@RequestBody JobsVO jobsVO) {
+//
+//		int cnt = worldCupService.insertWorldcupResult(jobsVO);
+//		
+//		return ResponseEntity.ok();
+//
+//	}
+	
 	
 	
 }

--- a/src/main/java/kr/or/ddit/worldcup/web/WorldCupController.java
+++ b/src/main/java/kr/or/ddit/worldcup/web/WorldCupController.java
@@ -1,0 +1,21 @@
+package kr.or.ddit.worldcup.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.or.ddit.worldcup.service.WorldCupService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/wouldcup")
+public class WorldCupController {
+
+	private final WorldCupService worldCupService;
+	
+	
+	
+}

--- a/src/main/resources/mybatis/mapper/worldcup-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/worldcup-Mapper.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="kr.or.ddit.worldcup.service.impl.WorldCupMapper">
+
+<!-- 직업분류 선택 32개 or 64 개 이상인 직업분류만-->
+<select id="selectCategories" parameterType="String" resultType="kr.or.ddit.worldcup.service.ComCodeVO">
+    SELECT c.CC_ID, c.CC_NAME
+    FROM COM_CODE c
+    JOIN (
+        SELECT JOB_LCL
+        FROM JOBS
+        GROUP BY JOB_LCL
+        HAVING COUNT(*) >= #{round}
+    ) j ON c.CC_ID = j.JOB_LCL
+    WHERE c.CL_CODE = 'G15'
+    ORDER BY c.CC_ID
+</select>
+
+<!-- 직업 분류에서 받아온 직업 목록 -->
+<select id="selectJobsByCategory" parameterType="kr.or.ddit.worldcup.service.ComCodeVO" resultType="kr.or.ddit.worldcup.service.JobsVO">
+	SELECT JOB_ID, JOB_NAME, JOB_LCL, JOB_RELATED_CERT, JOB_MAIN_DUTY
+		FROM JOBS
+		WHERE JOB_LCL = {ccId}
+		ORDER BY 1
+</select>
+
+<!-- 최종 결과 1등 직업 -->
+<select id="selectJobById" parameterType="kr.or.ddit.worldcup.service.JobsVO" resultType="kr.or.ddit.worldcup.service.JobsVO">
+	SELECT JOB_ID, JOB_CODE, JOB_NAME, JOB_LCL, JOB_MCL, JOB_SAL,
+			JOB_SATIS, JOB_PROSPECT, JOB_REQ_EDU,
+			JOB_RELATED_CERT, JOB_MAIN_DUTY
+	FROM JOBS
+	WHERE JOB_ID = {jobId}
+</select>
+
+
+<!-- 월드컵 데이터에 삽입 -->
+<insert id="insertWorldcupResult" parameterType="kr.or.ddit.worldcup.service.WorldCupVO">
+    <selectKey keyProperty="wdId" order="BEFORE" resultType="int">
+        SELECT NVL(MAX(WD_ID), 0) + 1 FROM WORLDCUP
+    </selectKey>
+
+    INSERT INTO WORLDCUP (WD_ID, WD_RESULT, CREATED_AT, MEM_ID)
+    VALUES (#{wdId}, #{wdResult}, SYSDATE, #{memId})
+</insert>
+
+
+
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/worldcup-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/worldcup-Mapper.xml
@@ -26,13 +26,20 @@
 
 <!-- 최종 결과 1등 직업 -->
 <select id="selectJobById" parameterType="kr.or.ddit.worldcup.service.JobsVO" resultType="kr.or.ddit.worldcup.service.JobsVO">
-	SELECT JOB_ID, JOB_CODE, JOB_NAME, JOB_LCL, JOB_MCL, JOB_SAL,
-			JOB_SATIS, JOB_PROSPECT, JOB_REQ_EDU,
-			JOB_RELATED_CERT, JOB_MAIN_DUTY
-	FROM JOBS
-	WHERE JOB_ID = {jobId}
+	SELECT JOB_CODE, JOB_NAME, JOB_LCL, JOB_SAL, JOB_SATIS,
+            JOB_WAY, JOB_RELATED_CERT, JOB_MAIN_DUTY
+	FROM JOBS 
+	WHERE JOB_CODE = #{jobCode}
 </select>
 
+<!-- 1등결과 관련 직종 가져오기 -->
+<select id="selectRelatedJobNames" parameterType="kr.or.ddit.worldcup.service.JobsVO" resultType="String">
+	SELECT JOB_NAME AS JOBS_REL
+	FROM JOBS
+	WHERE JOB_CODE IN (SELECT JR_CODE
+						FROM JOBS_REL
+						WHERE JOB_CODE = #{jobCode})
+</select>
 
 <!-- 월드컵 데이터에 삽입 -->
 <insert id="insertWorldcupResult" parameterType="kr.or.ddit.worldcup.service.WorldCupVO">

--- a/src/main/resources/mybatis/mapper/worldcup-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/worldcup-Mapper.xml
@@ -20,7 +20,7 @@
 <select id="selectJobsByCategory" parameterType="kr.or.ddit.worldcup.service.ComCodeVO" resultType="kr.or.ddit.worldcup.service.JobsVO">
 	SELECT JOB_CODE, JOB_NAME, JOB_LCL, JOB_RELATED_CERT, JOB_MAIN_DUTY
 		FROM JOBS
-		WHERE JOB_LCL = {ccId}
+		WHERE JOB_LCL = #{ccId}
 		ORDER BY 1
 </select>
 

--- a/src/main/resources/mybatis/mapper/worldcup-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/worldcup-Mapper.xml
@@ -18,7 +18,7 @@
 
 <!-- 직업 분류에서 받아온 직업 목록 -->
 <select id="selectJobsByCategory" parameterType="kr.or.ddit.worldcup.service.ComCodeVO" resultType="kr.or.ddit.worldcup.service.JobsVO">
-	SELECT JOB_ID, JOB_NAME, JOB_LCL, JOB_RELATED_CERT, JOB_MAIN_DUTY
+	SELECT JOB_CODE, JOB_NAME, JOB_LCL, JOB_RELATED_CERT, JOB_MAIN_DUTY
 		FROM JOBS
 		WHERE JOB_LCL = {ccId}
 		ORDER BY 1

--- a/src/main/resources/mybatis/mapper/worldcup-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/worldcup-Mapper.xml
@@ -51,7 +51,11 @@
     VALUES (#{wdId}, #{wdResult}, SYSDATE, #{memId})
 </insert>
 
-
+<select id="selectComCodeNameByccId" parameterType="kr.or.ddit.worldcup.service.ComCodeVO" resultType="kr.or.ddit.worldcup.service.ComCodeVO">
+	select CC_ID, CL_CODE, CC_NAME, CC_ETC
+	from COM_CODE
+	where CC_ID = #{ccId}
+</select>
 
 
 </mapper>

--- a/src/main/webapp/WEB-INF/views/include/header.jsp
+++ b/src/main/webapp/WEB-INF/views/include/header.jsp
@@ -53,7 +53,7 @@
           const worldcupUrl = 'http://localhost:5173/worldcup';
           
           const width  = 1200;
-          const height = 740;
+          const height = 800;
           const screenWidth  = window.screen.width;
           const screenHeight = window.screen.height;
              const left = Math.floor((screenWidth - width) / 2);

--- a/src/main/webapp/WEB-INF/views/include/header.jsp
+++ b/src/main/webapp/WEB-INF/views/include/header.jsp
@@ -21,8 +21,48 @@
 <script src="/js/include/header.js"></script>
 <script>
 	document.addEventListener("DOMContentLoaded",() => {
-		header();
-	});
+      const menuIcon = document.getElementById("menuToggle");
+      const dropdown = document.getElementById("dropdownMenu");
+      const roadmap  = document.getElementById("roadmap");
+	  header();
+
+      menuIcon.addEventListener("click",() => {
+        dropdown.classList.toggle("hidden");
+      });
+
+      document.addEventListener("click",(event) => {
+            if (!dropdown.contains(event.target) && !menuIcon.contains(event.target)) {
+               dropdown.classList.add("hidden");
+            }
+          });
+      
+      roadmap.addEventListener("click", () => {
+         const roadmapUrl = 'http://localhost:5173/roadmap';
+         
+         const width  = 1084;
+         const height = 736;
+         const screenWidth  = window.screen.width;
+         const screenHeight = window.screen.height;
+            const left = Math.floor((screenWidth - width) / 2);
+            const top  = Math.floor((screenHeight - height) / 2);
+         
+         window.open(roadmapUrl, 'Roadmap', `width=\${width}, height=\${height}, left=\${left}, top=\${top}`);
+      });
+      
+      worldcup.addEventListener("click", () => {
+          const worldcupUrl = 'http://localhost:5173/worldcup';
+          
+          const width  = 1084;
+          const height = 736;
+          const screenWidth  = window.screen.width;
+          const screenHeight = window.screen.height;
+             const left = Math.floor((screenWidth - width) / 2);
+             const top  = Math.floor((screenHeight - height) / 2);
+          
+          window.open(worldcupUrl, 'worldcup', `width=\${width}, height=\${height}, left=\${left}, top=\${top}`);
+       });
+       
+   	});
 	const memId = '<sec:authentication property="name" />'
 </script>
 </head>
@@ -79,8 +119,8 @@
 </div>
 
 <div class="right-fixed-bar">
-	<button class="right-fixed-btn">
-		<img src="/images/worldCup.png" alt="월드컵">
+    <button class="right-fixed-btn">
+		<img src="/images/worldCup.png" id="worldcup" alt="월드컵">
 	</button>
 	<button class="right-fixed-btn" id="chatRooms">
 		<img src="/images/chaticon.png" alt="채팅">

--- a/src/main/webapp/WEB-INF/views/include/header.jsp
+++ b/src/main/webapp/WEB-INF/views/include/header.jsp
@@ -52,8 +52,8 @@
       worldcup.addEventListener("click", () => {
           const worldcupUrl = 'http://localhost:5173/worldcup';
           
-          const width  = 1084;
-          const height = 736;
+          const width  = 1200;
+          const height = 740;
           const screenWidth  = window.screen.width;
           const screenHeight = window.screen.height;
              const left = Math.floor((screenWidth - width) / 2);

--- a/src/main/webapp/WEB-INF/views/include/header.jsp
+++ b/src/main/webapp/WEB-INF/views/include/header.jsp
@@ -23,7 +23,7 @@
 	document.addEventListener("DOMContentLoaded",() => {
       const menuIcon = document.getElementById("menuToggle");
       const dropdown = document.getElementById("dropdownMenu");
-      const roadmap  = document.getElementById("roadmap");
+      const worldcup = document.getElementById("worldcup");
 	  header();
 
       menuIcon.addEventListener("click",() => {
@@ -35,19 +35,6 @@
                dropdown.classList.add("hidden");
             }
           });
-      
-      roadmap.addEventListener("click", () => {
-         const roadmapUrl = 'http://localhost:5173/roadmap';
-         
-         const width  = 1084;
-         const height = 736;
-         const screenWidth  = window.screen.width;
-         const screenHeight = window.screen.height;
-            const left = Math.floor((screenWidth - width) / 2);
-            const top  = Math.floor((screenHeight - height) / 2);
-         
-         window.open(roadmapUrl, 'Roadmap', `width=\${width}, height=\${height}, left=\${left}, top=\${top}`);
-      });
       
       worldcup.addEventListener("click", () => {
           const worldcupUrl = 'http://localhost:5173/worldcup';


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
 - 직종별 월드컵 랜덤 32강 64강 구현
   - 32, 64 강 선택 후 가능한 직종 선택
 - 실제 토너먼트
   - 32 , 64 강에 맞춰 랜덤 직종에 맞는 랜덤 직업을 보여줍니다
   - 원하는 직업을 하나씩 선택해 최종 하나의 직업까지 선택 (결과창으로 이동)
 - 결과창
   - 직업에 대한 정보과 관련직업들을 안내해주고 월드컵 테이블에 1등 직종 삽입.
   - 다시하기 , 창닫기 버튼
## 스크린샷

## 주의사항

Closes #36
