### PR TITLE
[Feat] 결제관련 로그통계

### DIFF
--- a/src/main/java/kr/or/ddit/admin/las/service/PaymentStatsService.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/PaymentStatsService.java
@@ -22,4 +22,7 @@ public interface PaymentStatsService {
     
 	// 일일 구독 결제 매출
     public List<Map<String, Object>> getDailyRevenueForDashboard();
+
+    // AI 기능 이용 내역
+    List<Map<String, Object>> getAiServiceUsageStats(Map<String, Object> params);
 }

--- a/src/main/java/kr/or/ddit/admin/las/service/PaymentStatsService.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/PaymentStatsService.java
@@ -1,0 +1,5 @@
+package kr.or.ddit.admin.las.service;
+
+public interface PaymentStatsService {
+
+}

--- a/src/main/java/kr/or/ddit/admin/las/service/PaymentStatsService.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/PaymentStatsService.java
@@ -19,10 +19,16 @@ public interface PaymentStatsService {
 
     // 상품별 인기 통계 
     public List<Map<String, Object>> getProductPopularityStats(Map<String, Object> params);
-    
-	// 일일 구독 결제 매출
-    public List<Map<String, Object>> getDailyRevenueForDashboard();
 
     // AI 기능 이용 내역
-    List<Map<String, Object>> getAiServiceUsageStats(Map<String, Object> params);
+    public List<Map<String, Object>> getAiServiceUsageStats(Map<String, Object> params);
+   
+    // 일일 구독 결제 매출 - 대시보드용
+    public List<Map<String, Object>> getDailyRevenueForDashboard();
+
+	// 회원 가입 수 대비하여 구독 비율 - 대시보드용
+	public List<Map<String, Object>> selectNewUserRevenueRate();
+
+	// 총 구독 결제 대비하여 신규 구독 결제 비율 - 대시보드용
+	public List<Map<String, Object>> selectNewRevenueRateStats();
 }

--- a/src/main/java/kr/or/ddit/admin/las/service/PaymentStatsService.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/PaymentStatsService.java
@@ -1,5 +1,25 @@
 package kr.or.ddit.admin.las.service;
 
-public interface PaymentStatsService {
+import java.util.List;
+import java.util.Map;
 
+public interface PaymentStatsService {
+	
+	// 당일 기준 총 구독자 수
+    public int getTotalSubscriberCount();
+
+    // 당일 새로운 구독자 수
+    public int getNewSubscriberCountToday();
+
+    // 구독 결제 매출 
+    public List<Map<String, Object>> getRevenueStats(Map<String, Object> params);
+    
+    // 구독자 수 
+    public List<Map<String, Object>> getSubscriberCountStats(Map<String, Object> params);
+
+    // 상품별 인기 통계 
+    public List<Map<String, Object>> getProductPopularityStats(Map<String, Object> params);
+    
+	// 일일 구독 결제 매출
+    public List<Map<String, Object>> getDailyRevenueForDashboard();
 }

--- a/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsMapper.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsMapper.java
@@ -26,4 +26,7 @@ public interface PaymentStatsMapper {
 	// 일일 구독 결제 매출
 	public List<Map<String, Object>> selectDailyRevenueForDashboard();
 
+    // AI 기능 이용 내역
+	public List<Map<String, Object>> selectAiServiceUsageStats(Map<String, Object> params);
+
 }

--- a/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsMapper.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsMapper.java
@@ -11,22 +11,27 @@ public interface PaymentStatsMapper {
 	// 당일 기준 총 구독자 수
 	public int selectTotalSubscriberCount();
 
-    // 당일 새로운 구독자 수
+	// 당일 새로운 구독자 수
 	public int selectNewSubscriberCountToday();
 
-    // 구독 결제 매출 
+	// 구독 결제 매출
 	public List<Map<String, Object>> selectRevenueStats(Map<String, Object> params);
 
-    // 구독자 수 
+	// 구독자 수
 	public List<Map<String, Object>> selectSubscriberCountStats(Map<String, Object> params);
 
-    // 상품별 인기 통계 
+	// 상품별 인기 통계
 	public List<Map<String, Object>> selectProductPopularityStats(Map<String, Object> params);
 
-	// 일일 구독 결제 매출
+	// AI 기능 이용 내역
+	public List<Map<String, Object>> selectAiServiceUsageStats(Map<String, Object> params);
+	
+	// 일일 구독 결제 매출 - 대시보드용
 	public List<Map<String, Object>> selectDailyRevenueForDashboard();
 
-    // AI 기능 이용 내역
-	public List<Map<String, Object>> selectAiServiceUsageStats(Map<String, Object> params);
+	// 회원 가입 수 대비하여 구독 비율 - 대시보드용
+	public List<Map<String, Object>> selectNewUserRevenueRate();
 
+	// 총 구독 결제 대비하여 신규 구독 결제 비율 - 대시보드용
+	public List<Map<String, Object>> selectNewRevenueRateStats();
 }

--- a/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsMapper.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsMapper.java
@@ -1,0 +1,8 @@
+package kr.or.ddit.admin.las.service.impl;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PaymentStatsMapper {
+
+}

--- a/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsMapper.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsMapper.java
@@ -1,8 +1,29 @@
 package kr.or.ddit.admin.las.service.impl;
 
+import java.util.List;
+import java.util.Map;
+
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface PaymentStatsMapper {
+
+	// 당일 기준 총 구독자 수
+	public int selectTotalSubscriberCount();
+
+    // 당일 새로운 구독자 수
+	public int selectNewSubscriberCountToday();
+
+    // 구독 결제 매출 
+	public List<Map<String, Object>> selectRevenueStats(Map<String, Object> params);
+
+    // 구독자 수 
+	public List<Map<String, Object>> selectSubscriberCountStats(Map<String, Object> params);
+
+    // 상품별 인기 통계 
+	public List<Map<String, Object>> selectProductPopularityStats(Map<String, Object> params);
+
+	// 일일 구독 결제 매출
+	public List<Map<String, Object>> selectDailyRevenueForDashboard();
 
 }

--- a/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsServiceImpl.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsServiceImpl.java
@@ -1,0 +1,13 @@
+package kr.or.ddit.admin.las.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import kr.or.ddit.admin.las.service.PaymentStatsService;
+
+@Service
+public class PaymentStatsServiceImpl implements PaymentStatsService {
+	
+	@Autowired
+	private PaymentStatsMapper paymentStatsMapper;
+}

--- a/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsServiceImpl.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsServiceImpl.java
@@ -55,4 +55,11 @@ public class PaymentStatsServiceImpl implements PaymentStatsService {
 
 		return paymentStatsMapper.selectDailyRevenueForDashboard();
 	}
+
+    // AI 기능 이용 내역
+	@Override
+	public List<Map<String, Object>> getAiServiceUsageStats(Map<String, Object> params) {
+		
+		return paymentStatsMapper.selectAiServiceUsageStats(params);
+	}
 }

--- a/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsServiceImpl.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsServiceImpl.java
@@ -49,17 +49,31 @@ public class PaymentStatsServiceImpl implements PaymentStatsService {
         return paymentStatsMapper.selectProductPopularityStats(params);
 	}
 
-	// 일일 구독 결제 매출
+    // AI 기능 이용 내역
+	@Override
+	public List<Map<String, Object>> getAiServiceUsageStats(Map<String, Object> params) {
+		
+		return paymentStatsMapper.selectAiServiceUsageStats(params);
+	}
+
+	// 일일 구독 결제 매출 - 대시보드
 	@Override
 	public List<Map<String, Object>> getDailyRevenueForDashboard() {
 
 		return paymentStatsMapper.selectDailyRevenueForDashboard();
 	}
 
-    // AI 기능 이용 내역
+	// 회원 가입 수 대비하여 구독 비율 - 대시보드용
 	@Override
-	public List<Map<String, Object>> getAiServiceUsageStats(Map<String, Object> params) {
-		
-		return paymentStatsMapper.selectAiServiceUsageStats(params);
+	public List<Map<String, Object>> selectNewUserRevenueRate() {
+
+		return paymentStatsMapper.selectNewUserRevenueRate();
+	}
+
+	// 총 구독 결제 대비하여 신규 구독 결제 비율 - 대시보드용
+	@Override
+	public List<Map<String, Object>> selectNewRevenueRateStats() {
+
+		return paymentStatsMapper.selectNewRevenueRateStats();
 	}
 }

--- a/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsServiceImpl.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/impl/PaymentStatsServiceImpl.java
@@ -1,5 +1,8 @@
 package kr.or.ddit.admin.las.service.impl;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -10,4 +13,46 @@ public class PaymentStatsServiceImpl implements PaymentStatsService {
 	
 	@Autowired
 	private PaymentStatsMapper paymentStatsMapper;
+
+	// 당일 기준 총 구독자 수
+	@Override
+	public int getTotalSubscriberCount() {
+		
+		return paymentStatsMapper.selectTotalSubscriberCount();
+	}
+
+    // 당일 새로운 구독자 수
+	@Override
+	public int getNewSubscriberCountToday() {
+
+        return paymentStatsMapper.selectNewSubscriberCountToday();
+	}
+
+    // 구독 결제 매출 
+	@Override
+	public List<Map<String, Object>> getRevenueStats(Map<String, Object> params) {
+
+        return paymentStatsMapper.selectRevenueStats(params);
+	}
+
+    // 구독자 수 
+	@Override
+	public List<Map<String, Object>> getSubscriberCountStats(Map<String, Object> params) {
+
+        return paymentStatsMapper.selectSubscriberCountStats(params);
+	}
+
+    // 상품별 인기 통계 
+	@Override
+	public List<Map<String, Object>> getProductPopularityStats(Map<String, Object> params) {
+
+        return paymentStatsMapper.selectProductPopularityStats(params);
+	}
+
+	// 일일 구독 결제 매출
+	@Override
+	public List<Map<String, Object>> getDailyRevenueForDashboard() {
+
+		return paymentStatsMapper.selectDailyRevenueForDashboard();
+	}
 }

--- a/src/main/java/kr/or/ddit/admin/las/web/PaymentStatsController.java
+++ b/src/main/java/kr/or/ddit/admin/las/web/PaymentStatsController.java
@@ -55,4 +55,10 @@ public class PaymentStatsController {
     public List<Map<String, Object>> dailyRevenueForDashboard() {
         return paymentStatsService.getDailyRevenueForDashboard();
     }
+    
+	// AI 기능 이용 내역
+    @GetMapping("/ai-service-usage")
+    public List<Map<String, Object>> aiServiceUsage(@RequestParam Map<String, Object> params) {
+        return paymentStatsService.getAiServiceUsageStats(params);
+    }
 }

--- a/src/main/java/kr/or/ddit/admin/las/web/PaymentStatsController.java
+++ b/src/main/java/kr/or/ddit/admin/las/web/PaymentStatsController.java
@@ -1,0 +1,12 @@
+package kr.or.ddit.admin.las.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import kr.or.ddit.admin.las.service.PaymentStatsService;
+
+public class PaymentStatsController {
+	
+	@Autowired
+	private PaymentStatsService paymentStatsService;
+
+}

--- a/src/main/java/kr/or/ddit/admin/las/web/PaymentStatsController.java
+++ b/src/main/java/kr/or/ddit/admin/las/web/PaymentStatsController.java
@@ -49,16 +49,28 @@ public class PaymentStatsController {
     public List<Map<String, Object>> productPopularity(@RequestParam Map<String, Object> params) {
         return paymentStatsService.getProductPopularityStats(params);
     }
-
-	// 일일 구독 결제 매출
-    @GetMapping("/daily-revenue")
-    public List<Map<String, Object>> dailyRevenueForDashboard() {
-        return paymentStatsService.getDailyRevenueForDashboard();
-    }
     
 	// AI 기능 이용 내역
     @GetMapping("/ai-service-usage")
     public List<Map<String, Object>> aiServiceUsage(@RequestParam Map<String, Object> params) {
         return paymentStatsService.getAiServiceUsageStats(params);
+    }
+
+	// 일일 구독 결제 매출 - 대시보드용
+    @GetMapping("/daily-revenue")
+    public List<Map<String, Object>> dailyRevenueForDashboard() {
+        return paymentStatsService.getDailyRevenueForDashboard();
+    }
+    
+	// 회원 가입 수 대비하여 구독 비율 - 대시보드용
+    @GetMapping("/newUser-revenueRate")
+    public List<Map<String, Object>> newUserRevenueRate(){
+    	return paymentStatsService.selectNewUserRevenueRate();
+    }
+
+	// 총 구독 결제 대비하여 신규 구독 결제 비율 - 대시보드용
+    @GetMapping("/newRevenue-rateStats")
+    public List<Map<String, Object>> newRevenueRateStats(){
+    	return paymentStatsService.selectNewRevenueRateStats();
     }
 }

--- a/src/main/java/kr/or/ddit/admin/las/web/PaymentStatsController.java
+++ b/src/main/java/kr/or/ddit/admin/las/web/PaymentStatsController.java
@@ -1,12 +1,58 @@
 package kr.or.ddit.admin.las.web;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import kr.or.ddit.admin.las.service.PaymentStatsService;
+import lombok.extern.slf4j.Slf4j;
 
+@RestController
+@Slf4j
+@RequestMapping("/admin/las/payment")
 public class PaymentStatsController {
 	
 	@Autowired
 	private PaymentStatsService paymentStatsService;
 
+	// 당일 기준 총 구독자 수
+    @GetMapping("/total-subscribers")
+    public int totalSubscribers() {
+        return paymentStatsService.getTotalSubscriberCount();
+    }
+
+    // 당일 새로운 구독자 수
+    @GetMapping("/new-subscribers-today")
+    public int newSubscribersToday() {
+        return paymentStatsService.getNewSubscriberCountToday();
+    }
+
+    // 구독 결제 매출 
+    @GetMapping("/revenue-stats")
+	public List<Map<String, Object>> revenueStats(@RequestParam Map<String, Object> params) {
+        return paymentStatsService.getRevenueStats(params);
+    }
+
+    // 구독자 수 
+    @GetMapping("/subscriber-stats")
+    public List<Map<String, Object>> subscriberStats(@RequestParam Map<String, Object> params) {
+        return paymentStatsService.getSubscriberCountStats(params);
+    }
+
+    // 상품별 인기 통계 
+    @GetMapping("/product-popularity")
+    public List<Map<String, Object>> productPopularity(@RequestParam Map<String, Object> params) {
+        return paymentStatsService.getProductPopularityStats(params);
+    }
+
+	// 일일 구독 결제 매출
+    @GetMapping("/daily-revenue")
+    public List<Map<String, Object>> dailyRevenueForDashboard() {
+        return paymentStatsService.getDailyRevenueForDashboard();
+    }
 }

--- a/src/main/java/kr/or/ddit/admin/las/web/VisitLogController.java
+++ b/src/main/java/kr/or/ddit/admin/las/web/VisitLogController.java
@@ -30,6 +30,16 @@ public class VisitLogController {
 		visitLogService.insertPageLog(memId, "채팅", "/chat", null);
 	}
 	
+	@PostMapping("/las/aiResumeVisitLog.do")
+	public void aiResumeVisitLog(@AuthenticationPrincipal String memId) {
+		visitLogService.insertPageLog(memId, "이력서AI요청", "/aiResume", null);
+	}
+
+	@PostMapping("/las/aiSelfIntroVisitLog.do")
+	public void aiSelfIntroVisitLog(@AuthenticationPrincipal String memId) {
+		visitLogService.insertPageLog(memId, "자기소개서AI요청", "/aiSelfIntro", null);
+	}
+	
 	
 	
 }

--- a/src/main/java/kr/or/ddit/admin/las/web/VisitLogController.java
+++ b/src/main/java/kr/or/ddit/admin/las/web/VisitLogController.java
@@ -2,13 +2,13 @@ package kr.or.ddit.admin.las.web;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import kr.or.ddit.admin.las.service.VisitLogService;
 
-@Controller
+@RestController
 @RequestMapping("/admin")
 public class VisitLogController {
 	

--- a/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
@@ -139,4 +139,53 @@
 	    LEFT JOIN REVENUE R ON D."dt" = R."dt"
 	    ORDER BY D."dt" ASC
 	</select>
+	
+	<!-- 
+	// AI 기능 이용 내역
+	public List<Map<String, Object>> selectAiServiceUsageStats(Map<String, Object> params);
+	 -->
+	<select id="selectAiServiceUsageStats" parameterType="map" resultType="map">
+	    SELECT
+	        <choose>
+	            <when test="period == 'monthly'">TO_CHAR(l.PL_CREATED_AT, 'YYYY-MM')</when>
+	            <otherwise>TO_CHAR(l.PL_CREATED_AT, 'YYYY-MM-DD')</otherwise>
+	        </choose> AS "dt",
+	        
+	        -- '나의 활동 - 이력서' 로그 카운트
+	        COUNT(CASE WHEN l.PL_TITLE = '나의 활동 - 이력서' THEN 1 END) AS "resumeCnt",
+	        
+	        -- '나의 활동 - 자기소개서' 로그 카운트
+	        COUNT(CASE WHEN l.PL_TITLE = '나의 활동 - 자기소개서' THEN 1 END) AS "coverCnt"
+	        
+	        -- 참고: 모의면접 로그가 있다면 여기에 추가
+	        -- COUNT(CASE WHEN l.PL_TITLE = '...' THEN 1 END) AS "mockCnt"
+	        
+	    FROM PAGE_LOG l
+	    JOIN MEMBER m ON l.MEM_ID = m.MEM_ID
+	    WHERE 
+	        l.PL_TITLE IN ('나의 활동 - 이력서', '나의 활동 - 자기소개서')
+	        
+	        <if test="from != null and from != ''">AND l.PL_CREATED_AT >= TO_DATE(#{from}, 'YYYY-MM-DD')</if>
+	        <if test="to != null and to != ''">AND l.PL_CREATED_AT &lt; TO_DATE(#{to}, 'YYYY-MM-DD') + 1</if>
+	        
+	        <if test="gender != null and gender != '' and gender != 'ALL'">AND m.MEM_GEN = #{gender}</if>
+	        
+	        <if test="ageBand != null and ageBand != '' and ageBand != 'ALL'">
+	          AND m.MEM_BIRTH IS NOT NULL
+	          AND CASE
+	                WHEN FLOOR(MONTHS_BETWEEN(TRUNC(l.PL_CREATED_AT), m.MEM_BIRTH)/12) &lt; 20 THEN '10대'
+	                WHEN FLOOR(MONTHS_BETWEEN(TRUNC(l.PL_CREATED_AT), m.MEM_BIRTH)/12) BETWEEN 20 AND 29 THEN '20대'
+	                WHEN FLOOR(MONTHS_BETWEEN(TRUNC(l.PL_CREATED_AT), m.MEM_BIRTH)/12) BETWEEN 30 AND 39 THEN '30대'
+	                ELSE '40대 이상'
+	              END = #{ageBand}
+	        </if>
+	        
+	    GROUP BY 
+	        <choose>
+	            <when test="period == 'monthly'">TO_CHAR(l.PL_CREATED_AT, 'YYYY-MM')</when>
+	            <otherwise>TO_CHAR(l.PL_CREATED_AT, 'YYYY-MM-DD')</otherwise>
+	        </choose>
+	        
+	    ORDER BY "dt" ASC
+	</select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
@@ -213,13 +213,13 @@
 	                <otherwise>TO_CHAR(CREATED_AT, 'YYYY-MM-DD')</otherwise>
 	            </choose>
 	    ),
-	    NEW_SUBS_REVENUE AS (
+	    NEW_SUBS AS (
 	        SELECT
 	            <choose>
 	                <when test="period == 'monthly'">TO_CHAR(P.PAY_DATE, 'YYYY-MM')</when>
 	                <otherwise>TO_CHAR(P.PAY_DATE, 'YYYY-MM-DD')</otherwise>
 	            </choose> AS "dt",
-	            SUM(P.PAY_AMOUNT) AS "newSubscriberRevenue"
+	            COUNT(*) AS "newSubscriberCount"
 	        FROM PAYMENT P
 	        JOIN MEMBER_SUBSCRIPTION MS ON P.MS_ID = MS.MS_ID
 	        WHERE 
@@ -240,13 +240,13 @@
 	    SELECT
 	        d."dt",
 	        d."newMemberCount",
-	        NVL(s."newSubscriberRevenue", 0) AS "newSubscriberRevenue",
+	        NVL(s."newSubscriberCount", 0) AS "newSubscriberCount",
 	        CASE
-	            WHEN d."newMemberCount" > 0 THEN ROUND(NVL(s."newSubscriberRevenue", 0) / d."newMemberCount")
+	            WHEN d."newMemberCount" > 0 THEN ROUND(NVL(s."newSubscriberCount", 0) / d."newMemberCount")
 	            ELSE 0
-	        END AS "revenuePerNewMember" -- 신규 가입자 1명당 평균 매출
+	        END AS "conversionRate" -- 신규 가입자 1명당 평균 매출
 	    FROM NEW_MEMBERS d
-	    LEFT JOIN NEW_SUBS_REVENUE s ON d."dt" = s."dt"
+	    LEFT JOIN NEW_SUBS s ON d."dt" = s."dt"
 	    ORDER BY d."dt" ASC
 	</select>
 	

--- a/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
@@ -101,9 +101,11 @@
         FROM MEMBER_SUBSCRIPTION MS
         JOIN PAYMENT P ON P.MS_ID = MS.MS_ID
         JOIN SUBSCRIBE S ON S.SUB_ID = MS.SUB_ID
+        JOIN MEMBER M ON M.MEM_ID = MS.MEM_ID
         WHERE 1=1
             <if test="from != null and from != ''">AND P.PAY_DATE >= TO_DATE(#{from}, 'YYYY-MM-DD')</if>
             <if test="to != null and to != ''">AND P.PAY_DATE &lt; TO_DATE(#{to}, 'YYYY-MM-DD') + 1</if>
+            <if test="gender != null and gender != '' and gender != 'ALL'">AND M.MEM_GEN = #{gender}</if>
         GROUP BY 
             <choose>
                 <when test="period == 'monthly'">TO_CHAR(P.PAY_DATE, 'YYYY-MM')</when>
@@ -114,7 +116,7 @@
     </select>
 
 	<!-- 
-	// 일일 구독 결제 매출
+	// 일일 구독 결제 매출 - 대시보드용
 	public List<Map<String, Object>> selectDailyRevenueForDashboard();
 	 -->	
 	<select id="selectDailyRevenueForDashboard" resultType="map">

--- a/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
@@ -154,18 +154,18 @@
 	        </choose> AS "dt",
 	        
 	        -- '나의 활동 - 이력서' 로그 카운트
-	        COUNT(CASE WHEN l.PL_TITLE = '나의 활동 - 이력서' THEN 1 END) AS "resumeCnt",
+	        COUNT(CASE WHEN l.PL_TITLE = '이력서AI요청' THEN 1 END) AS "resumeCnt",
 	        
 	        -- '나의 활동 - 자기소개서' 로그 카운트
-	        COUNT(CASE WHEN l.PL_TITLE = '나의 활동 - 자기소개서' THEN 1 END) AS "coverCnt"
+	        COUNT(CASE WHEN l.PL_TITLE = '자기소개서AI요청' THEN 1 END) AS "coverCnt"
 	        
 	        -- 참고: 모의면접 로그가 있다면 여기에 추가
-	        -- COUNT(CASE WHEN l.PL_TITLE = '...' THEN 1 END) AS "mockCnt"
+	        -- COUNT(CASE WHEN l.PL_TITLE = '모의면접AI요청' THEN 1 END) AS "mockCnt"
 	        
 	    FROM PAGE_LOG l
 	    JOIN MEMBER m ON l.MEM_ID = m.MEM_ID
 	    WHERE 
-	        l.PL_TITLE IN ('나의 활동 - 이력서', '나의 활동 - 자기소개서')
+	        l.PL_TITLE IN ('이력서AI요청', '자기소개서AI요청' ,'모의면접AI요청')
 	        
 	        <if test="from != null and from != ''">AND l.PL_CREATED_AT >= TO_DATE(#{from}, 'YYYY-MM-DD')</if>
 	        <if test="to != null and to != ''">AND l.PL_CREATED_AT &lt; TO_DATE(#{to}, 'YYYY-MM-DD') + 1</if>

--- a/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
@@ -1,7 +1,142 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="kr.or.ddit.admin.las.service.impl.PaymentStatsMapper">
-
+	
+	<!-- 
+	// 당일 기준 총 구독자 수
+	public int selectTotalSubscriberCount();
+	 -->
+	<select id="selectTotalSubscriberCount">
+        SELECT
+	        COUNT(DISTINCT MEM_ID)
+	    FROM
+	        MEMBER_SUBSCRIPTION
+	    WHERE
+	        TRUNC(SUB_END_DT) >= TRUNC(SYSDATE)
+    </select>
  
+ 	<!-- 
+ 	// 당일 새로운 구독자 수
+	public int selectNewSubscriberCountToday();
+	 -->
+	<select id="selectNewSubscriberCountToday">
+        SELECT
+        	COUNT(*)
+	    FROM PAYMENT P
+	    JOIN MEMBER_SUBSCRIPTION MS ON P.MS_ID = MS.MS_ID
+	    WHERE 
+	        TRUNC(P.PAY_DATE) = TRUNC(SYSDATE)
+	        AND P.PAY_DATE = (
+	            SELECT MIN(P2.PAY_DATE)
+	            FROM PAYMENT P2
+	            JOIN MEMBER_SUBSCRIPTION MS2 ON P2.MS_ID = MS2.MS_ID
+	            WHERE MS2.MEM_ID = MS.MEM_ID
+	        )
+    </select>
+	 
+	<!-- 
+	 // 구독 결제 매출 
+	public List<Map<String, Object>> selectRevenueStats(Map<String, Object> params);
+	 --> 
+	<select id="selectRevenueStats" parameterType="map" resultType="map">
+        SELECT
+            <choose>
+                <when test="period == 'monthly'">TO_CHAR(p.PAY_DATE, 'YYYY-MM')</when>
+                <otherwise>TO_CHAR(p.PAY_DATE, 'YYYY-MM-DD')</otherwise>
+            </choose> AS "dt",
+            SUM(p.PAY_AMOUNT) AS "revenue"
+        FROM PAYMENT p
+        JOIN MEMBER_SUBSCRIPTION ms ON p.MS_ID = ms.MS_ID
+        JOIN MEMBER m ON ms.MEM_ID = m.MEM_ID
+        WHERE p.PAY_AMOUNT > 0
+          <if test="from != null and from != ''">AND p.PAY_DATE >= TO_DATE(#{from}, 'YYYY-MM-DD')</if>
+          <if test="to != null and to != ''">AND p.PAY_DATE &lt; TO_DATE(#{to}, 'YYYY-MM-DD') + 1</if>
+          <if test="gender != null and gender != '' and gender != 'ALL'">AND m.MEM_GEN = #{gender}</if>
+        GROUP BY 
+            <choose>
+                <when test="period == 'monthly'">TO_CHAR(p.PAY_DATE, 'YYYY-MM')</when>
+                <otherwise>TO_CHAR(p.PAY_DATE, 'YYYY-MM-DD')</otherwise>
+            </choose>
+        ORDER BY "dt" ASC
+    </select>
+	
+	<!-- 
+	// 구독자 수 
+	public List<Map<String, Object>> selectSubscriberCountStats(Map<String, Object> params);
+	 -->
+	<select id="selectSubscriberCountStats" parameterType="map" resultType="map">
+        SELECT
+            <choose>
+                <when test="period == 'monthly'">TO_CHAR(P.PAY_DATE, 'YYYY-MM')</when>
+                <otherwise>TO_CHAR(P.PAY_DATE, 'YYYY-MM-DD')</otherwise>
+            </choose> AS "dt",
+            COUNT(*) AS "count"
+        FROM MEMBER_SUBSCRIPTION MS
+        JOIN PAYMENT P ON P.MS_ID = MS.MS_ID
+        JOIN MEMBER M ON M.MEM_ID = MS.MEM_ID
+        WHERE 1=1
+            <if test="from != null and from != ''">AND P.PAY_DATE >= TO_DATE(#{from}, 'YYYY-MM-DD')</if>
+            <if test="to != null and to != ''">AND P.PAY_DATE &lt; TO_DATE(#{to}, 'YYYY-MM-DD') + 1</if>
+            <if test="gender != null and gender != '' and gender != 'ALL'">AND M.MEM_GEN = #{gender}</if>
+        GROUP BY 
+            <choose>
+                <when test="period == 'monthly'">TO_CHAR(P.PAY_DATE, 'YYYY-MM')</when>
+                <otherwise>TO_CHAR(P.PAY_DATE, 'YYYY-MM-DD')</otherwise>
+            </choose>
+        ORDER BY "dt" ASC
+    </select>
+	
+	 <!-- 
+	 // 상품별 인기 통계 
+	public List<Map<String, Object>> selectProductPopularityStats(Map<String, Object> params);
+	  -->
+	<select id="selectProductPopularityStats" parameterType="map" resultType="map">
+        SELECT
+            <choose>
+                <when test="period == 'monthly'">TO_CHAR(P.PAY_DATE, 'YYYY-MM')</when>
+                <otherwise>TO_CHAR(P.PAY_DATE, 'YYYY-MM-DD')</otherwise>
+            </choose> AS "dt",
+            S.SUB_NAME AS "subName",
+            COUNT(*) AS "count"
+        FROM MEMBER_SUBSCRIPTION MS
+        JOIN PAYMENT P ON P.MS_ID = MS.MS_ID
+        JOIN SUBSCRIBE S ON S.SUB_ID = MS.SUB_ID
+        WHERE 1=1
+            <if test="from != null and from != ''">AND P.PAY_DATE >= TO_DATE(#{from}, 'YYYY-MM-DD')</if>
+            <if test="to != null and to != ''">AND P.PAY_DATE &lt; TO_DATE(#{to}, 'YYYY-MM-DD') + 1</if>
+        GROUP BY 
+            <choose>
+                <when test="period == 'monthly'">TO_CHAR(P.PAY_DATE, 'YYYY-MM')</when>
+                <otherwise>TO_CHAR(P.PAY_DATE, 'YYYY-MM-DD')</otherwise>
+            </choose>,
+            S.SUB_NAME
+        ORDER BY "dt", "subName"
+    </select>
 
+	<!-- 
+	// 일일 구독 결제 매출
+	public List<Map<String, Object>> selectDailyRevenueForDashboard();
+	 -->	
+	<select id="selectDailyRevenueForDashboard" resultType="map">
+	    WITH DATES AS (
+	      SELECT TRUNC(SYSDATE) - LEVEL + 1 AS "dt"
+	      FROM DUAL
+	      CONNECT BY LEVEL &lt;= 7
+	    ),
+	    REVENUE AS (
+	        SELECT
+	            TRUNC(PAY_DATE) AS "dt",
+	            SUM(PAY_AMOUNT) AS "revenue"
+	        FROM PAYMENT
+	        WHERE PAY_DATE >= TRUNC(SYSDATE) - 6
+	          AND PAY_AMOUNT > 0
+	        GROUP BY TRUNC(PAY_DATE)
+	    )
+	    SELECT
+	        TO_CHAR(D."dt", 'YYYY-MM-DD') AS "dt",
+	        NVL(R."revenue", 0) AS "revenue"
+	    FROM DATES D
+	    LEFT JOIN REVENUE R ON D."dt" = R."dt"
+	    ORDER BY D."dt" ASC
+	</select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
@@ -114,33 +114,6 @@
             S.SUB_NAME
         ORDER BY "dt", "subName"
     </select>
-
-	<!-- 
-	// 일일 구독 결제 매출 - 대시보드용
-	public List<Map<String, Object>> selectDailyRevenueForDashboard();
-	 -->	
-	<select id="selectDailyRevenueForDashboard" resultType="map">
-	    WITH DATES AS (
-	      SELECT TRUNC(SYSDATE) - LEVEL + 1 AS "dt"
-	      FROM DUAL
-	      CONNECT BY LEVEL &lt;= 7
-	    ),
-	    REVENUE AS (
-	        SELECT
-	            TRUNC(PAY_DATE) AS "dt",
-	            SUM(PAY_AMOUNT) AS "revenue"
-	        FROM PAYMENT
-	        WHERE PAY_DATE >= TRUNC(SYSDATE) - 6
-	          AND PAY_AMOUNT > 0
-	        GROUP BY TRUNC(PAY_DATE)
-	    )
-	    SELECT
-	        TO_CHAR(D."dt", 'YYYY-MM-DD') AS "dt",
-	        NVL(R."revenue", 0) AS "revenue"
-	    FROM DATES D
-	    LEFT JOIN REVENUE R ON D."dt" = R."dt"
-	    ORDER BY D."dt" ASC
-	</select>
 	
 	<!-- 
 	// AI 기능 이용 내역
@@ -189,5 +162,152 @@
 	        </choose>
 	        
 	    ORDER BY "dt" ASC
+	</select>
+
+	<!-- 
+	// 일일 구독 결제 매출 - 대시보드용
+	public List<Map<String, Object>> selectDailyRevenueForDashboard();
+	 -->	
+	<select id="selectDailyRevenueForDashboard" resultType="map">
+	    WITH DATES AS (
+	      SELECT TRUNC(SYSDATE) - LEVEL + 1 AS "dt"
+	      FROM DUAL
+	      CONNECT BY LEVEL &lt;= 7
+	    ),
+	    REVENUE AS (
+	        SELECT
+	            TRUNC(PAY_DATE) AS "dt",
+	            SUM(PAY_AMOUNT) AS "revenue"
+	        FROM PAYMENT
+	        WHERE PAY_DATE >= TRUNC(SYSDATE) - 6
+	          AND PAY_AMOUNT > 0
+	        GROUP BY TRUNC(PAY_DATE)
+	    )
+	    SELECT
+	        TO_CHAR(D."dt", 'YYYY-MM-DD') AS "dt",
+	        NVL(R."revenue", 0) AS "revenue"
+	    FROM DATES D
+	    LEFT JOIN REVENUE R ON D."dt" = R."dt"
+	    ORDER BY D."dt" ASC
+	</select>
+	
+	<!-- 
+	// 회원 가입 수 대비하여 구독 비율 - 대시보드용
+	public List<Map<String, Object>> selectNewUserRevenueRate();
+	 -->	
+	<select id="selectNewUserRevenueRate" parameterType="map" resultType="map">
+	    WITH NEW_MEMBERS AS (
+	        SELECT
+	            <choose>
+	                <when test="period == 'monthly'">TO_CHAR(CREATED_AT, 'YYYY-MM')</when>
+	                <otherwise>TO_CHAR(CREATED_AT, 'YYYY-MM-DD')</otherwise>
+	            </choose> AS "dt",
+	            COUNT(*) AS "newMemberCount"
+	        FROM MEMBER
+	        WHERE 1=1
+	            <if test="from != null and from != ''">AND CREATED_AT >= TO_DATE(#{from}, 'YYYY-MM-DD')</if>
+	            <if test="to != null and to != ''">AND CREATED_AT &lt; TO_DATE(#{to}, 'YYYY-MM-DD') + 1</if>
+	        GROUP BY 
+	            <choose>
+	                <when test="period == 'monthly'">TO_CHAR(CREATED_AT, 'YYYY-MM')</when>
+	                <otherwise>TO_CHAR(CREATED_AT, 'YYYY-MM-DD')</otherwise>
+	            </choose>
+	    ),
+	    NEW_SUBS_REVENUE AS (
+	        SELECT
+	            <choose>
+	                <when test="period == 'monthly'">TO_CHAR(P.PAY_DATE, 'YYYY-MM')</when>
+	                <otherwise>TO_CHAR(P.PAY_DATE, 'YYYY-MM-DD')</otherwise>
+	            </choose> AS "dt",
+	            SUM(P.PAY_AMOUNT) AS "newSubscriberRevenue"
+	        FROM PAYMENT P
+	        JOIN MEMBER_SUBSCRIPTION MS ON P.MS_ID = MS.MS_ID
+	        WHERE 
+	            P.PAY_DATE = (
+	                SELECT MIN(P2.PAY_DATE)
+	                FROM PAYMENT P2
+	                JOIN MEMBER_SUBSCRIPTION MS2 ON P2.MS_ID = MS2.MS_ID
+	                WHERE MS2.MEM_ID = MS.MEM_ID
+	            )
+	            <if test="from != null and from != ''">AND P.PAY_DATE >= TO_DATE(#{from}, 'YYYY-MM-DD')</if>
+	            <if test="to != null and to != ''">AND P.PAY_DATE &lt; TO_DATE(#{to}, 'YYYY-MM-DD') + 1</if>
+	        GROUP BY
+	            <choose>
+	                <when test="period == 'monthly'">TO_CHAR(P.PAY_DATE, 'YYYY-MM')</when>
+	                <otherwise>TO_CHAR(P.PAY_DATE, 'YYYY-MM-DD')</otherwise>
+	            </choose>
+	    )
+	    SELECT
+	        d."dt",
+	        d."newMemberCount",
+	        NVL(s."newSubscriberRevenue", 0) AS "newSubscriberRevenue",
+	        CASE
+	            WHEN d."newMemberCount" > 0 THEN ROUND(NVL(s."newSubscriberRevenue", 0) / d."newMemberCount")
+	            ELSE 0
+	        END AS "revenuePerNewMember" -- 신규 가입자 1명당 평균 매출
+	    FROM NEW_MEMBERS d
+	    LEFT JOIN NEW_SUBS_REVENUE s ON d."dt" = s."dt"
+	    ORDER BY d."dt" ASC
+	</select>
+	
+	
+	
+	<!-- 
+	// 총 구독 결제 대비하여 신규 구독 결제 비율 - 대시보드용
+	public List<Map<String, Object>> selectNewRevenueRateStats();
+	 -->	
+	<select id="selectNewRevenueRateStats" parameterType="map" resultType="map">
+	    WITH TOTAL_REVENUE AS (
+	        SELECT
+	            <choose>
+	                <when test="period == 'monthly'">TO_CHAR(P.PAY_DATE, 'YYYY-MM')</when>
+	                <otherwise>TO_CHAR(P.PAY_DATE, 'YYYY-MM-DD')</otherwise>
+	            </choose> AS "dt",
+	            SUM(P.PAY_AMOUNT) AS "totalRevenue"
+	        FROM PAYMENT P
+	        WHERE 1=1
+	            <if test="from != null and from != ''">AND P.PAY_DATE >= TO_DATE(#{from}, 'YYYY-MM-DD')</if>
+	            <if test="to != null and to != ''">AND P.PAY_DATE &lt; TO_DATE(#{to}, 'YYYY-MM-DD') + 1</if>
+	        GROUP BY 
+	            <choose>
+	                <when test="period == 'monthly'">TO_CHAR(P.PAY_DATE, 'YYYY-MM')</when>
+	                <otherwise>TO_CHAR(P.PAY_DATE, 'YYYY-MM-DD')</otherwise>
+	            </choose>
+	    ),
+	    NEW_SUB_REVENUE AS (
+	        SELECT
+	            <choose>
+	                <when test="period == 'monthly'">TO_CHAR(P.PAY_DATE, 'YYYY-MM')</when>
+	                <otherwise>TO_CHAR(P.PAY_DATE, 'YYYY-MM-DD')</otherwise>
+	            </choose> AS "dt",
+	            SUM(P.PAY_AMOUNT) AS "newSubscriberRevenue"
+	        FROM PAYMENT P
+	        JOIN MEMBER_SUBSCRIPTION MS ON P.MS_ID = MS.MS_ID
+	        WHERE 
+	            P.PAY_DATE = (
+	                SELECT MIN(P2.PAY_DATE)
+	                FROM PAYMENT P2
+	                JOIN MEMBER_SUBSCRIPTION MS2 ON P2.MS_ID = MS2.MS_ID
+	                WHERE MS2.MEM_ID = MS.MEM_ID
+	            )
+	            <if test="from != null and from != ''">AND P.PAY_DATE >= TO_DATE(#{from}, 'YYYY-MM-DD')</if>
+	            <if test="to != null and to != ''">AND P.PAY_DATE &lt; TO_DATE(#{to}, 'YYYY-MM-DD') + 1</if>
+	        GROUP BY
+	            <choose>
+	                <when test="period == 'monthly'">TO_CHAR(P.PAY_DATE, 'YYYY-MM')</when>
+	                <otherwise>TO_CHAR(P.PAY_DATE, 'YYYY-MM-DD')</otherwise>
+	            </choose>
+	    )
+	    SELECT
+	        d."dt",
+	        NVL(d."totalRevenue", 0) AS "totalRevenue",
+	        NVL(s."newSubscriberRevenue", 0) AS "newSubscriberRevenue",
+	        CASE
+	            WHEN d."totalRevenue" > 0 THEN ROUND((NVL(s."newSubscriberRevenue", 0) / d."totalRevenue") * 100, 2)
+	            ELSE 0
+	        END AS "newRevenueRate" -- 신규 매출 비율 (%)
+	    FROM TOTAL_REVENUE d
+	    LEFT JOIN NEW_SUB_REVENUE s ON d."dt" = s."dt"
+	    ORDER BY d."dt" ASC
 	</select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
@@ -126,10 +126,10 @@
 	            <otherwise>TO_CHAR(l.PL_CREATED_AT, 'YYYY-MM-DD')</otherwise>
 	        </choose> AS "dt",
 	        
-	        -- '나의 활동 - 이력서' 로그 카운트
+	        -- '이력서AI요청' 로그 카운트
 	        COUNT(CASE WHEN l.PL_TITLE = '이력서AI요청' THEN 1 END) AS "resumeCnt",
 	        
-	        -- '나의 활동 - 자기소개서' 로그 카운트
+	        -- '자기소개서AI요청' 로그 카운트
 	        COUNT(CASE WHEN l.PL_TITLE = '자기소개서AI요청' THEN 1 END) AS "coverCnt"
 	        
 	        -- 참고: 모의면접 로그가 있다면 여기에 추가
@@ -244,7 +244,7 @@
 	        CASE
 	            WHEN d."newMemberCount" > 0 THEN ROUND(NVL(s."newSubscriberCount", 0) / d."newMemberCount")
 	            ELSE 0
-	        END AS "conversionRate" -- 신규 가입자 1명당 평균 매출
+	        END AS "conversionRate" -- 신규 가입자 대비 신규 구독
 	    FROM NEW_MEMBERS d
 	    LEFT JOIN NEW_SUBS s ON d."dt" = s."dt"
 	    ORDER BY d."dt" ASC

--- a/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/paymentStats-Mapper.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="kr.or.ddit.admin.las.service.impl.PaymentStatsMapper">
+
+ 
+
+</mapper>

--- a/src/main/resources/static/css/cdp/aifdbck/rsm/aiFeedbackResume.css
+++ b/src/main/resources/static/css/cdp/aifdbck/rsm/aiFeedbackResume.css
@@ -142,14 +142,13 @@
 	background-color: #3e3bdb;
 }
 
-.aifb-button.back {
-	background: #E9E9E9;
-	color: #9C9B9D;
+.aifb-button.proofread {
+	background: #5a57f0;
+	color: #FFFFFF;
 }
 
-.aifb-button.proofread {
-	background: #848EFB;
-	color: #FFFFFF;
+.aifb-button.proofread:hover {
+	background: #3e3bdb;
 }
 
 /* 하단 버튼 영역 */
@@ -157,9 +156,24 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	margin-top: 30px;
 	width: 100%;
 	box-sizing: border-box;
+}
+
+.ai-feedback-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 20px;
+    gap: 5px;
+}
+
+.powered-by-text {
+    font-family: 'IBM Plex Sans KR';
+    font-size: 11px;
+    color: #888;
+    font-weight: 400;
+    letter-spacing: 0.3px;
 }
 
 /* =================================================== */

--- a/src/main/resources/static/css/cdp/aifdbck/sint/aiFeedbackSelfIntro.css
+++ b/src/main/resources/static/css/cdp/aifdbck/sint/aiFeedbackSelfIntro.css
@@ -128,24 +128,37 @@
 	background-color: #3e3bdb;
 }
 
-.aifb-button.back {
-	background: #E9E9E9;
-	color: #9C9B9D;
+.aifb-button.proofread {
+	background: #5a57f0;
+	color: #FFFFFF;
 }
 
-.aifb-button.proofread {
-	background: #848EFB;
-	color: #FFFFFF;
+.aifb-button.proofread:hover {
+	background: #3e3bdb;
 }
 
 .aifb-footer-wrapper {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	margin-top: 30px;
 	width: 100%;
 	box-sizing: border-box;
-	padding: 0;
+}
+
+.ai-feedback-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 20px;
+    gap: 5px;
+}
+
+.powered-by-text {
+    font-family: 'IBM Plex Sans KR';
+    font-size: 11px;
+    color: #888;
+    font-weight: 400;
+    letter-spacing: 0.3px;
 }
 
 .answer-block {

--- a/src/main/resources/static/js/cdp/aifdbck/rsm/aiFeedbackResume.js
+++ b/src/main/resources/static/js/cdp/aifdbck/rsm/aiFeedbackResume.js
@@ -157,7 +157,8 @@ document.addEventListener('DOMContentLoaded', () => {
 				feedbackArea.innerHTML = aiResponseText.replace(/\n/g, '<br>');
 				subscriptionInfo.payResumeCnt--;
 				alert(`AI 피드백이 완료되었습니다. (남은 횟수: ${subscriptionInfo.payResumeCnt}회)`);
-
+				
+				axios.post(`/las/aiResumeVisitLog.do `)
 				// 화면 표시
 				//document.getElementById('feedbackArea').innerHTML = cleanedText.replace(/\n/g, '<br>');
 			})

--- a/src/main/resources/static/js/cdp/aifdbck/rsm/aiFeedbackResume.js
+++ b/src/main/resources/static/js/cdp/aifdbck/rsm/aiFeedbackResume.js
@@ -158,7 +158,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				subscriptionInfo.payResumeCnt--;
 				alert(`AI 피드백이 완료되었습니다. (남은 횟수: ${subscriptionInfo.payResumeCnt}회)`);
 				
-				axios.post(`/las/aiResumeVisitLog.do `)
+				axios.post('/admin/las/aiResumeVisitLog.do')
 				// 화면 표시
 				//document.getElementById('feedbackArea').innerHTML = cleanedText.replace(/\n/g, '<br>');
 			})

--- a/src/main/resources/static/js/cdp/aifdbck/sint/aiFeedbackSelfIntro.js
+++ b/src/main/resources/static/js/cdp/aifdbck/sint/aiFeedbackSelfIntro.js
@@ -162,7 +162,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			})
 			.then(aiResponseText => {
 
-				axios.post(`/las/aiSelfIntroVisitLog.do`)
+				axios.post('/admin/las/aiSelfIntroVisitLog.do')
 				// AI 응답 텍스트를 정리하고 파싱
 				const cleanedText = cleanAiResponse(aiResponseText);
 

--- a/src/main/resources/static/js/cdp/aifdbck/sint/aiFeedbackSelfIntro.js
+++ b/src/main/resources/static/js/cdp/aifdbck/sint/aiFeedbackSelfIntro.js
@@ -161,6 +161,8 @@ document.addEventListener('DOMContentLoaded', () => {
 				return response.text().then(text => Promise.reject(new Error(text)));
 			})
 			.then(aiResponseText => {
+
+				axios.post(`/las/aiSelfIntroVisitLog.do`)
 				// AI 응답 텍스트를 정리하고 파싱
 				const cleanedText = cleanAiResponse(aiResponseText);
 
@@ -178,6 +180,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				// ⭐️ 성공 시 로컬 자소서 횟수 1 차감 후 알림
 				subscriptionInfo.payCoverCnt--;
 				alert(`AI 피드백이 완료되었습니다. (남은 횟수: ${subscriptionInfo.payCoverCnt}회)`);
+				
 			})
 			.catch(error => {
 				console.error('AI 피드백 요청 오류:', error);

--- a/src/main/webapp/WEB-INF/views/cdp/aifdbck/rsm/aiFeedbackResume.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/aifdbck/rsm/aiFeedbackResume.jsp
@@ -57,9 +57,11 @@
 
 				<!-- 하단 버튼 -->
 				<div class="aifb-footer-wrapper">
-					<button class="aifb-button back" onclick="history.back()">뒤로가기</button>
-					<button id="requestAiFeedback" class="aifb-button feedback">ai 피드백 요청</button>
-					<button class="aifb-button proofread" onclick="requestProofread()">내 이력서 수정하러 가기</button>
+				    <div class="ai-feedback-section">
+				        <button id="requestAiFeedback" class="aifb-button feedback">AI 피드백 요청</button>
+				        <span class="powered-by-text">Powered by Gemini</span>
+				    </div>
+				    <button class="aifb-button proofread" onclick="requestProofread()">내 이력서 수정하러 가기</button>
 				</div>
 			</div>
 		</div>

--- a/src/main/webapp/WEB-INF/views/cdp/aifdbck/sint/aiFeedbackSelfIntro.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/aifdbck/sint/aiFeedbackSelfIntro.jsp
@@ -61,9 +61,11 @@
 				</div>
 
 				<div class="aifb-footer-wrapper">
-					<button class="aifb-button back" onclick="history.back()">뒤로가기</button>
-					<button id="requestAiFeedback" class="aifb-button feedback">ai 피드백 요청</button>
-					<button class="aifb-button proofread" onclick="requestProofread()">내 자기소개서 수정하러 가기</button>
+				    <div class="ai-feedback-section">
+				        <button id="requestAiFeedback" class="aifb-button feedback">AI 피드백 요청</button>
+				        <span class="powered-by-text">Powered by Gemini</span>
+				    </div>
+				    <button class="aifb-button proofread" onclick="requestProofread()">내 이력서 수정하러 가기</button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
결제 관련 통계
 - 결제/프리미엄 서비스 통계
    - 당일 기준 총 구독자수
    - 당일 새로운 구독자 수
    - 구독 결제 매출 / 필터(성별, 일별, 월별, 기간별)
    - 구독자수 / 필터(성별, 일별, 월별, 기간별)
    - 상품별 인기 통계 / 필터(성별, 일별, 월별, 기간별)
    - AI 기능 이용내역 / 필터(성별, 일별, 월별, 기간별)

 - 대시보드용 통계
    - 일일 구독 결제 매출
    - 회원 가입 수 대비하여 구독 비율
    - 총 구독 결제 대비하여 신규 구독 결제 비율

AI 기능 이용내역을 위해 js에서 로그를 보내기 위해 axios.post 코드를 삽입

## 스크린샷

## 주의사항

현재 AI 기능 이용내역은 PAGE_LOG를 이용하는데 아직 로그연동이 안되었기에
불러오는 로그타이틀은 사전에 미리 정하고 연동할것을 가정하고 쿼리를 정함

Closes #173
