### PR TITLE
[feat] 관리자 사용자관리 정렬,필터 일부 수정작업

### DIFF
--- a/src/main/java/kr/or/ddit/admin/las/service/UsageStatsService.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/UsageStatsService.java
@@ -6,14 +6,14 @@ import kr.or.ddit.main.service.MemberVO;
 import kr.or.ddit.util.ArticlePage;
 
 public interface UsageStatsService {
-	
+
 	// 현재 로그인한 사용자 정보 조회
 	public ArticlePage<MemberVO> liveUserList(int currentPage, int size, String keyword, String gen, String loginType);
-	
+
 	// 일별/월별/기간별 사용자 구하기
-	public List<UsageStatsVO> userInqury(String selectUserInquiry, String startDate, String endDate, String gender);
+	public List<UsageStatsVO> userInqury(String selectUserInquiry, String startDate, String endDate, String gender, String ageGroup);
 
 	// 일별/월별/기간별 페이지 방문자 수 조회 TOP10
-	public List<VisitVO> visitCount(String selectVisitCount, String startDate, String endDate, String gender);
+	public List<VisitVO> visitCount(String selectVisitCount, String startDate, String endDate, String gender, String ageGroup);
 
 }

--- a/src/main/java/kr/or/ddit/admin/las/service/impl/UsageStatsMapper.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/impl/UsageStatsMapper.java
@@ -13,26 +13,26 @@ import kr.or.ddit.main.service.MemberVO;
 public interface UsageStatsMapper {
 
 	// 일별 사용자 구하기
-	public List<UsageStatsVO> dailyUserInquiry(String gender);
+	public List<UsageStatsVO> dailyUserInquiry(String gender, String ageGroup);
 
 	// 월별 사용자 구하기
-	public List<UsageStatsVO> monthlyUserInquiry(String gender);
-	
+	public List<UsageStatsVO> monthlyUserInquiry(String gender, String ageGroup);
+
 	// 원하는 기간별 방문자 수
-	public List<UsageStatsVO> customUserInquiry(String startDate, String endDate,String gender);
+	public List<UsageStatsVO> customUserInquiry(String startDate, String endDate,String gender, String ageGroup);
 
 	// 로그인한 사용자 정보 조회
 	public List<MemberVO> liveUserList(Map<String, Object> map);
 
 	// 건수 조회
 	public int liveUserListCount(Map<String, Object> map);
-	
+
 	// 일별 페이지 방문자 수 TOP10
-	public List<VisitVO> dailyPageVisitCount(String gender);
+	public List<VisitVO> dailyPageVisitCount(String gender, String ageGroup);
 
 	// 해당월 페이지 방문자 수 top10
-	public List<VisitVO> monthlyPageVisitCount(String gender);
-	
+	public List<VisitVO> monthlyPageVisitCount(String gender, String ageGroup);
+
 	// 원하는 기간별 페이지 방문자 수
-	public List<VisitVO> customPageVisitCount(String startDate, String endDate, String gender);
+	public List<VisitVO> customPageVisitCount(String startDate, String endDate, String gender, String ageGroup);
 }

--- a/src/main/java/kr/or/ddit/admin/las/service/impl/UsageStatsServiceImpl.java
+++ b/src/main/java/kr/or/ddit/admin/las/service/impl/UsageStatsServiceImpl.java
@@ -19,52 +19,58 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 public class UsageStatsServiceImpl implements UsageStatsService{
-	
+
 	@Autowired
 	UsageStatsMapper usageStatsMapper;
-	
+
 	// 일별/월별/기간별 사용자 구하기
 	@Override
-	public List<UsageStatsVO> userInqury(String selectUserInquiry, String startDate, String endDate, String gender) {
-		// TODO Auto-generated method stub
-		
+	public List<UsageStatsVO> userInqury(String selectUserInquiry, String startDate, String endDate, String gender, String ageGroup) {
+		// 앞 단에서 male, female값으로 넘겼을 때 대응
+		if(gender!=null && "male".equals(gender)) gender = "G11001";
+		if(gender!=null && "female".equals(gender)) gender = "G11002";
+
 		List<UsageStatsVO> list = new ArrayList<>();
-		
+
 		if(selectUserInquiry.equals("daily")) {
-			list = usageStatsMapper.dailyUserInquiry(gender);
+			list = usageStatsMapper.dailyUserInquiry(gender, ageGroup);
 		}else if(selectUserInquiry.equals("monthly")) {
-			list = usageStatsMapper.monthlyUserInquiry(gender);		
+			list = usageStatsMapper.monthlyUserInquiry(gender, ageGroup);
 		}else if(selectUserInquiry.equals("selectDays")) {
-			list= usageStatsMapper.customUserInquiry(startDate,endDate,gender);
+			list= usageStatsMapper.customUserInquiry(startDate,endDate,gender,ageGroup);
 		}
-		
+
 		return list;
 	}
-	
-	
+
+
 
 	@Override
-	public List<VisitVO> visitCount(String selectVisitCount, String startDate, String endDate, String gender) {
+	public List<VisitVO> visitCount(String selectVisitCount, String startDate, String endDate, String gender, String ageGroup) {
 		List<VisitVO> list = new ArrayList<>();
-		
+
+		// 앞 단에서 male, female값으로 넘겼을 때 대응
+		if(gender!=null && "male".equals(gender)) gender = "G11001";
+		if(gender!=null && "female".equals(gender)) gender = "G11002";
+
 		if(selectVisitCount.equals("daily")) {
-			list = usageStatsMapper.dailyPageVisitCount(gender);
+			list = usageStatsMapper.dailyPageVisitCount(gender, ageGroup);
 		}else if(selectVisitCount.equals("monthly")) {
-			list = usageStatsMapper.monthlyPageVisitCount(gender);		
+			list = usageStatsMapper.monthlyPageVisitCount(gender, ageGroup);
 		}else if(selectVisitCount.equals("selectDays")) {
-			list= usageStatsMapper.customPageVisitCount(startDate,endDate,gender);
+			list= usageStatsMapper.customPageVisitCount(startDate,endDate,gender, ageGroup);
 		}
-		
+
 		return list;
 	}
 
-	
+
 	@Override
 	public ArticlePage<MemberVO> liveUserList(int currentPage, int size, String keyword, String gen, String loginType) {
 		// 파라미터
 		int startNo = (currentPage - 1) * size + 1;
 		int endNo = currentPage * size;
-		
+
 		Map<String, Object> map = new HashMap<String, Object>();
 		map.put("keyword", keyword);
 		map.put("gen", gen);
@@ -72,16 +78,16 @@ public class UsageStatsServiceImpl implements UsageStatsService{
 		map.put("currentPage", currentPage);
 		map.put("startNo", startNo);
 		map.put("endNo", endNo);
-		
+
 		// 리스트 불러오기
 		List<MemberVO> memList =  usageStatsMapper.liveUserList(map);
-		
+
 		// 건수
 		int total = usageStatsMapper.liveUserListCount(map);
 		// 페이지 네이션
 		ArticlePage<MemberVO> articlePage = new ArticlePage<MemberVO>(total, currentPage, size, memList, keyword);
-		
+
 		return articlePage;
 	}
-	
+
 }

--- a/src/main/java/kr/or/ddit/admin/las/web/UsageStatsController.java
+++ b/src/main/java/kr/or/ddit/admin/las/web/UsageStatsController.java
@@ -29,43 +29,43 @@ public class UsageStatsController {
 
 	@Autowired
 	UsageStatsService usageStatsService;
-	
+
 	/*
 	 * 사용 방법:
-	 * 필수 파라미터 : 
-	 * 	1. userInquiry - selectUserInquiry 
-	 *  2. visitCount - selectVisitCount 
-	 *  3. daily(일) / monthly(월) / selectDays(기간별) 로 해주셔야 합니다.  
-	 *  
+	 * 필수 파라미터 :
+	 * 	1. userInquiry - selectUserInquiry
+	 *  2. visitCount - selectVisitCount
+	 *  3. daily(일) / monthly(월) / selectDays(기간별) 로 해주셔야 합니다.
+	 *
 	 *  보내는 방식 : post
 	 * */
-	
-	
+
+
 	@GetMapping("/userInquiry.do")
 	public List<UsageStatsVO>userInquiry(@RequestParam(value="selectUserInquiry", defaultValue ="daily" )String selectUserInquiry,
 			@RequestParam(value="startDate", required = false) String startDate,
 			@RequestParam(value="endDate", required = false) String endDate,
-			@RequestParam(value="gender", required = false) String gender){
-		
-		
-		List<UsageStatsVO> list = usageStatsService.userInqury(selectUserInquiry,startDate,endDate,gender);
-		
+			@RequestParam(value="gender", required = false) String gender,
+			@RequestParam(value="ageGroup", required = false) String ageGroup){
+
+		List<UsageStatsVO> list = usageStatsService.userInqury(selectUserInquiry,startDate,endDate,gender,ageGroup);
 		return list;
 	}
-	
-	
+
+
 	// 페이지별 방문자 조회
 	@GetMapping("/visitCount.do")
 	public List<VisitVO> visitCount(@RequestParam(value="selectVisitCount", defaultValue ="daily" )String selectVisitCount,
 			@RequestParam(value="startDate", required = false) String startDate,
 			@RequestParam(value="endDate", required = false) String endDate,
-			@RequestParam(value="gender", required = false) String gender){
-		
-		List<VisitVO> list = usageStatsService.visitCount(selectVisitCount,startDate,endDate,gender);
-		
+			@RequestParam(value="gender", required = false) String gender,
+			@RequestParam(value="ageGroup", required = false) String ageGroup){
+
+		List<VisitVO> list = usageStatsService.visitCount(selectVisitCount,startDate,endDate,gender,ageGroup);
+
 		return list;
 	}
-	
+
 	// 실시간 사용자 조회
 	@GetMapping("/liveUserList.do")
 	public ArticlePage<MemberVO> liveUserList(@RequestParam(value="currentPage",required=false,defaultValue="1") int currentPage,
@@ -75,9 +75,9 @@ public class UsageStatsController {
 			@RequestParam(value="gen",required = false)String gen,
 			//로그인 구분
 			@RequestParam(value="loginType",required = false)String loginType){
-		
+
 		ArticlePage<MemberVO> memList = usageStatsService.liveUserList(currentPage, size, keyword, gen, loginType);
-		
+
 		return memList;
 	}
 }

--- a/src/main/resources/mybatis/mapper/usageStats-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/usageStats-Mapper.xml
@@ -24,6 +24,12 @@
 		<if test="gender != null and gender eq 'G11002'">
 			AND m.MEM_GEN = 'G11002'
 		</if>
+		<if test="ageGroup != null and ageGroup != '' and ageGroup eq 'teen'">
+	    	AND TRUNC(MONTHS_BETWEEN(ll.LL_CREATED_AT, m.MEM_BIRTH) / 12) &lt;= 19
+	    </if>
+	    <if test="ageGroup != null and ageGroup != '' and ageGroup eq 'youth'">
+	    	AND TRUNC(MONTHS_BETWEEN(ll.LL_CREATED_AT, m.MEM_BIRTH) / 12) &gt;= 20
+	    </if>
 	    <![CDATA[
 	        GROUP BY TO_CHAR(ll.LL_CREATED_AT, 'YYYY-MM-DD')
 	    )
@@ -61,6 +67,12 @@
 		    <if test="gender != null and gender eq 'G11002'">
 		        AND m.MEM_GEN = 'G11002'
 		    </if>
+		    <if test="ageGroup != null and ageGroup != '' and ageGroup eq 'teen'">
+		    	AND TRUNC(MONTHS_BETWEEN(ll.LL_CREATED_AT, m.MEM_BIRTH) / 12) &lt;= 19
+		    </if>
+		    <if test="ageGroup != null and ageGroup != '' and ageGroup eq 'youth'">
+		    	AND TRUNC(MONTHS_BETWEEN(ll.LL_CREATED_AT, m.MEM_BIRTH) / 12) &gt;= 20
+		    </if>
 		<![CDATA[
 		    GROUP BY TO_CHAR(ll.LL_CREATED_AT, 'YYYY-MM')
 		)
@@ -80,10 +92,10 @@
 		WITH date_list AS (
 		    SELECT TRUNC(TO_DATE(#{startDate}, 'YYYY-MM-DD')) + LEVEL - 1 AS login_date
 		    FROM dual
-		    CONNECT BY LEVEL <= TRUNC(TO_DATE(#{endDate}, 'YYYY-MM-DD')) 
+		    CONNECT BY LEVEL <= TRUNC(TO_DATE(#{endDate}, 'YYYY-MM-DD'))
 		                        - TRUNC(TO_DATE(#{startDate}, 'YYYY-MM-DD')) + 1
 		),
-		
+
 		daily_login_counts AS (
 		    SELECT
 		        TO_CHAR(ll.LL_CREATED_AT, 'YYYY-MM-DD') AS login_date,
@@ -99,6 +111,12 @@
 		    </if>
 		    <if test="gender != null and gender == 'G11002'">
 		        AND m.MEM_GEN = 'G11002'
+		    </if>
+			<if test="ageGroup != null and ageGroup != '' and ageGroup eq 'teen'">
+		    	AND TRUNC(MONTHS_BETWEEN(ll.LL_CREATED_AT, m.MEM_BIRTH) / 12) &lt;= 19
+		    </if>
+		    <if test="ageGroup != null and ageGroup != '' and ageGroup eq 'youth'">
+		    	AND TRUNC(MONTHS_BETWEEN(ll.LL_CREATED_AT, m.MEM_BIRTH) / 12) &gt;= 20
 		    </if>
 		<![CDATA[
 		    GROUP BY TO_CHAR(ll.LL_CREATED_AT, 'YYYY-MM-DD')
@@ -229,6 +247,12 @@
 	        <if test="gender != null and gender eq 'G11002'">
 	            <![CDATA[ AND m.MEM_GEN = 'G11002' ]]>
 	        </if>
+	        <if test="ageGroup != null and ageGroup != '' and ageGroup eq 'teen'">
+		    	AND TRUNC(MONTHS_BETWEEN(pl.PL_CREATED_AT, m.MEM_BIRTH) / 12) &lt;= 19
+		    </if>
+		    <if test="ageGroup != null and ageGroup != '' and ageGroup eq 'youth'">
+		    	AND TRUNC(MONTHS_BETWEEN(pl.PL_CREATED_AT, m.MEM_BIRTH) / 12) &gt;= 20
+		    </if>
 	    <![CDATA[
 	        GROUP BY PL_TITLE
 	        ORDER BY userCount DESC
@@ -236,8 +260,8 @@
 	    WHERE ROWNUM <= 10
 	    ]]>
 	</select>
-	
-	
+
+
 	<select id="monthlyPageVisitCount" resultType="kr.or.ddit.admin.las.service.VisitVO">
 	    <![CDATA[
 	    SELECT *
@@ -254,6 +278,12 @@
 	        <if test="gender != null and gender eq 'G11002'">
 	            <![CDATA[ AND m.MEM_GEN = 'G11002' ]]>
 	        </if>
+      	    <if test="ageGroup != null and ageGroup != '' and ageGroup eq 'teen'">
+		    	AND TRUNC(MONTHS_BETWEEN(pl.PL_CREATED_AT, m.MEM_BIRTH) / 12) &lt;= 19
+		    </if>
+		    <if test="ageGroup != null and ageGroup != '' and ageGroup eq 'youth'">
+		    	AND TRUNC(MONTHS_BETWEEN(pl.PL_CREATED_AT, m.MEM_BIRTH) / 12) &gt;= 20
+		    </if>
 	    <![CDATA[
 	        GROUP BY PL_TITLE
 	        ORDER BY userCount DESC
@@ -262,8 +292,8 @@
 	    ]]>
 	</select>
 
-	
-	
+
+
 	<select id="customPageVisitCount" resultType="kr.or.ddit.admin.las.service.VisitVO">
 	    <![CDATA[
 	    SELECT *
@@ -280,6 +310,12 @@
 	        <if test="gender != null and gender eq 'G11002'">
 	            <![CDATA[ AND m.MEM_GEN = 'G11002' ]]>
 	        </if>
+           	<if test="ageGroup != null and ageGroup != '' and ageGroup eq 'teen'">
+		    	AND TRUNC(MONTHS_BETWEEN(pl.PL_CREATED_AT, m.MEM_BIRTH) / 12) &lt;= 19
+		    </if>
+		    <if test="ageGroup != null and ageGroup != '' and ageGroup eq 'youth'">
+		    	AND TRUNC(MONTHS_BETWEEN(pl.PL_CREATED_AT, m.MEM_BIRTH) / 12) &gt;= 20
+		    </if>
 	    <![CDATA[
 	        GROUP BY PL_TITLE
 	        ORDER BY userCount DESC

--- a/src/main/resources/static/js/include/admin/umg/memberManagement.js
+++ b/src/main/resources/static/js/include/admin/umg/memberManagement.js
@@ -14,10 +14,12 @@ function memberManagement() {
 	const boardListIdBtn = document.getElementById('memDetailBoardList-orderBtn-id');
 	const boardListDateBtn = document.getElementById('memDetailBoardList-orderBtn-date');
 	const boardListdelYnBtn = document.getElementById('memDetailBoardList-orderBtn-delYn');
+	const boardListSortOrder = document.getElementById("memDetailSortOrder");
 
 	const replyListIdBtn = document.getElementById('memDetailReplyList-orderBtn-id');
 	const replyListDateBtn = document.getElementById('memDetailReplyList-orderBtn-date');
 	const replyListDelYnBtn = document.getElementById('memDetailReplyList-orderBtn-delYn');
+	const replyListSortOrder = document.getElementById("memDetailReplySortOrder");
 
 	/* 사용자 접속 통계 셀렉트 요소로 수정 */
 	const userOnlineChartDaySel = document.getElementById('userOnlineChartDay');
@@ -41,6 +43,51 @@ function memberManagement() {
 	pageVisitChartDaySel.addEventListener('change', eventDateRangeSelect);
 	pageVisitChartGenderSel.addEventListener('change', pageVisitChart);
 	pageVisitChartAgeGroupSel.addEventListener('change', pageVisitChart);
+
+	replyListSortOrder.addEventListener('click', function() {
+		const userId = document.getElementById('mem-id').value;
+		if (!userId) {
+			alert('회원을 선택하세요.');
+		}
+	})
+
+	replyListSortOrder.addEventListener('change', function(e){
+		const userId = document.getElementById('mem-id').value;
+		const currentSortValEl = e.target.closest('.userDetailBtnGroup').querySelector('.public-toggle-button.active');
+		switch (currentSortValEl.id){
+					case "memDetailReplyList-orderBtn-id" :
+						handleReplySortClick('replyId',userId);
+						break;
+					case "memDetailReplyList-orderBtn-delYn" :
+						handleReplySortClick('replyDelYn',userId);
+						break;
+					case "memDetailReplyList-orderBtn-date" :
+						handleReplySortClick('replyCreatedAt',userId);
+						break;
+				}
+	})
+
+	boardListSortOrder.addEventListener('click', function(){
+		const userId = document.getElementById('mem-id').value;
+		if(!userId){
+			alert('회원을 선택하세요.');
+		}
+	})
+	boardListSortOrder.addEventListener('change', function(e){
+		const userId = document.getElementById('mem-id').value;
+		const currentSortValEl = e.target.closest('.userDetailBtnGroup').querySelector('.public-toggle-button.active');
+		switch (currentSortValEl.id){
+					case "memDetailBoardList-orderBtn-id" :
+						handleBoardSortClick('boardId',userId);
+						break;
+					case "memDetailBoardList-orderBtn-delYn" :
+						handleBoardSortClick('boardDelYn',userId);
+						break;
+					case "memDetailBoardList-orderBtn-date" :
+						handleBoardSortClick('boardCreatedAt',userId);
+						break;
+				}
+	})
 
 	userListSortOrder.addEventListener('change', function(e){
 		const currentSortValEl = e.target.closest('.userListBtnGroup').querySelector('.public-toggle-button.active');
@@ -202,33 +249,30 @@ function memberManagement() {
 	// 게시글 목록 정렬 처리
 	function handleBoardSortClick(sortBy, userId, element) {
 		const boardTbody = document.getElementById('userDetailBoardList');
-
-		let sortOrder = 'asc';
-		if (boardTbody.dataset.sortBy === sortBy) {
-			sortOrder = boardTbody.dataset.sortOrder === 'asc' ? 'desc' : 'asc';
-		}
+		const boardSortOrder = document.getElementById('memDetailSortOrder').value;
 
 		boardTbody.dataset.sortBy = sortBy;
-		boardTbody.dataset.sortOrder = sortOrder;
+		boardTbody.dataset.sortOrder = boardSortOrder;
 
-		setActiveButton(element);
+		if(element){
+			setActiveButton(element);
+		}
 		const category = document.getElementById('boardListCategory').value;
+		const sortOrder = boardTbody.dataset.sortOrder;
 		userDetailBoardList(userId, 1, sortBy, sortOrder, category);
 	}
 
 	// 댓글 목록 정렬 처리 함수
 	function handleReplySortClick(sortBy, userId, element) {
 		const replyTbody = document.getElementById('userDetailReplyList');
-
-		let sortOrder = 'asc';
-		if (replyTbody.dataset.sortBy === sortBy) {
-			sortOrder = replyTbody.dataset.sortOrder === 'asc' ? 'desc' : 'asc';
-		}
+		const replySortOrder = document.getElementById('memDetailReplySortOrder').value;
 
 		replyTbody.dataset.sortBy = sortBy;
-		replyTbody.dataset.sortOrder = sortOrder;
-
-		setActiveButton(element);
+		replyTbody.dataset.sortOrder = replySortOrder;
+		if(element){
+			setActiveButton(element);
+		}
+		const sortOrder = replyTbody.dataset.sortOrder;
 		userDetailReplyList(userId, 1, sortBy, sortOrder);
 	}
 
@@ -1432,7 +1476,7 @@ function memberManagement() {
 	setInterval(fetchDailyStats, 10000);
 
 	//=== flatpicker 달력 선택된 날자 yyyy-mm-dd 문자열로 포맷팅
-	function formatDate(d){
+	function formatDateCal(d){
 		const y = d.getFullYear();
 		const m = String(d.getMonth() + 1).padStart(2, '0');
 		const day = String(d.getDate()).padStart(2, '0');
@@ -1487,8 +1531,8 @@ function memberManagement() {
 						const startDate = selectedDates[0];
 						const endDate = selectedDates[1];
 						// yyyy-mm-dd 형식으로 포맷
-						const formattedStartDate = formatDate(startDate);
-						const formattedEndDate = formatDate(endDate);
+						const formattedStartDate = formatDateCal(startDate);
+						const formattedEndDate = formatDateCal(endDate);
 						if(selectEl.id == 'userOnlineChartDay'){
 							// hidden 날짜 input에 데이터 삽입
 							document.getElementById('userOnlineChartStartDay').value=formattedStartDate;

--- a/src/main/resources/static/js/include/admin/umg/memberManagement.js
+++ b/src/main/resources/static/js/include/admin/umg/memberManagement.js
@@ -1130,7 +1130,6 @@ function memberManagement() {
 						gender: genderValue||gender,
 						ageGroup: ageGroupValue||'',
 					}
-		console.log(params);
 
 		// 차트 캔버스 높이 설정 (안정적인 렌더링을 위해 추가)
 		ctx.canvas.style.minHeight = '400px';
@@ -1240,7 +1239,6 @@ function memberManagement() {
 						gender: genderValue||gender,
 						ageGroup: ageGroupValue||'',
 					}
-		console.log(params);
 
 		// 기존 차트 파괴 및 최소 높이 설정
 		if (window.pageVisitChartInstance) {
@@ -1489,7 +1487,6 @@ function memberManagement() {
 
 	// 일별, 월별, 기간선택에 대해서 이벤트 바인딩
 	function eventDateRangeSelect(e){
-		console.log(e);
 		// 공용으로 사용할 숨겨둔 input. flatpickr가 input 요소인지 점검한다고 함.(select에 못줌)
 		const selectEl = e.target.nodeName == "SELECT" ? e.target : e.target.closest('select');
 		const dateValue = selectEl.value;

--- a/src/main/resources/static/js/include/admin/umg/memberManagement.js
+++ b/src/main/resources/static/js/include/admin/umg/memberManagement.js
@@ -9,6 +9,7 @@ function memberManagement() {
 	const userListIdBtn = document.getElementById('userListId');
 	const userListNameBtn = document.getElementById('userListName');
 	const userListEmailBtn = document.getElementById('userListEmail');
+	const userListSortOrder = document.getElementById('userListSortOrder');
 
 	const boardListIdBtn = document.getElementById('memDetailBoardList-orderBtn-id');
 	const boardListDateBtn = document.getElementById('memDetailBoardList-orderBtn-date');
@@ -40,6 +41,21 @@ function memberManagement() {
 	pageVisitChartDaySel.addEventListener('change', eventDateRangeSelect);
 	pageVisitChartGenderSel.addEventListener('change', pageVisitChart);
 	pageVisitChartAgeGroupSel.addEventListener('change', pageVisitChart);
+
+	userListSortOrder.addEventListener('change', function(e){
+		const currentSortValEl = e.target.closest('.userListBtnGroup').querySelector('.public-toggle-button.active');
+		switch (currentSortValEl.id){
+			case "userListId" :
+				handleSortClick('id');
+				break;
+			case "userListName" :
+				handleSortClick('name');
+				break;
+			case "userListEmail" :
+				handleSortClick('email');
+				break;
+		}
+	})
 
 	selector.addEventListener('change', function() {
 		// 모든 테이블을 숨김
@@ -176,17 +192,11 @@ function memberManagement() {
 	// 유저 목록 정렬 처리
 	function handleSortClick(sortBy) {
 
-		if (currentSortBy !== sortBy) {
-			currentSortBy = sortBy;
-			currentSortOrder = 'asc';
-		} else {
-
-			currentSortOrder = currentSortOrder === 'asc' ? 'desc' : 'asc';
-		}
+		const sortOrder = document.getElementById("userListSortOrder").value;
 
 		// 2. handleSortClick에서 fetchUserList를 호출할 때 inFilter 값을 가져와서 전달
 		const userListInFilter = document.getElementById('userListStatus').value;
-		fetchUserList(currentPage, currentSortBy, currentSortOrder, userListInFilter);
+		fetchUserList(currentPage, sortBy, sortOrder, userListInFilter);
 	}
 
 	// 게시글 목록 정렬 처리

--- a/src/main/webapp/WEB-INF/views/admin/umg/memberManagement.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/umg/memberManagement.jsp
@@ -60,6 +60,10 @@
 				<button class="public-toggle-button active" id="userListId">ID</button>
 				<button class="public-toggle-button" id="userListName">이름</button>
 				<button class="public-toggle-button" id="userListEmail">이메일</button>
+				<select class="public-toggle-select" id="userListSortOrder">
+					<option value="asc">오름차순</option>
+					<option value="desc">내림차순</option>
+				</select>
 			</div>
 			<select class="public-toggle-select selectUserList-top" id="userListStatus">
 				<option value="">전체</option>

--- a/src/main/webapp/WEB-INF/views/admin/umg/memberManagement.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/umg/memberManagement.jsp
@@ -3,6 +3,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 <script src="/js/include/admin/umg/memberManagement.js"></script>
 <h2 style="color: gray; font-size: 18px; margin: 0; line-height: 75px;">회원 관리</h2>
+<input type="hidden" id="comCalendarInput" />
 <div class="member-1 flex gap">
 	<div class="template-panel public-countCard">
 		<div class="public-card-title">일일 사용자 현황</div>
@@ -65,7 +66,7 @@
 				<option value="online">활동중</option>
 				<option value="offline">비활동</option>
 				<option value="suspended">정지상태</option>
-				
+
 			</select>
 		</div>
 		<div class="userListSpace">
@@ -320,6 +321,23 @@
 	<div class="template-panel" style="width: 792.5px;">
 		<div class="middleTitle">사용자 접속 통계</div>
 		<div class="btn-group flex gap5 userOnlineChart">
+		<input type="hidden" id="userOnlineChartStartDay" />
+		<input type="hidden" id="userOnlineChartEndDay" />
+		<select class="public-toggle-select" name="userOnlineChartDay" id="userOnlineChartDay">
+			<option value="daily">일별</option>
+			<option value="monthly">월별</option>
+			<option value="selectDays">기간선택</option>
+		</select>
+		<select class="public-toggle-select" name="userOnlineChartGender" id="userOnlineChartGender">
+			<option value="">성별전체</option>
+			<option value="male">남자</option>
+			<option value="female">여자</option>
+		</select>
+		<select class="public-toggle-select" name="userOnlineChartAgeGroup" id="userOnlineChartAgeGroup">
+			<option value="">성별전체</option>
+			<option value="male">남자</option>
+			<option value="female">여자</option>
+		</select>
 			<button class="public-toggle-button active" id="userOnlineChartDayBtn">일별</button>
 			<button class="public-toggle-button" id="userOnlineChartMonthBtn">월별</button>
 			<button class="public-toggle-button" id="userOnlineChartMaleBtn">남성</button>

--- a/src/main/webapp/WEB-INF/views/admin/umg/memberManagement.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/umg/memberManagement.jsp
@@ -238,6 +238,10 @@
 						<button class="public-toggle-button active" id="memDetailBoardList-orderBtn-id">ID</button>
 						<button class="public-toggle-button" id="memDetailBoardList-orderBtn-delYn">삭제여부</button>
 						<button class="public-toggle-button" id="memDetailBoardList-orderBtn-date">작성일자</button>
+						<select class="public-toggle-select" id="memDetailSortOrder">
+							<option value="asc">오름차순</option>
+							<option value="desc">내림차순</option>
+						</select>
 					</div>
 					<select class="public-toggle-select selectpb-top" id="boardListCategory">
 						<option value="">전체</option>
@@ -274,6 +278,10 @@
 					<button class="public-toggle-button active" id="memDetailReplyList-orderBtn-id">ID</button>
 					<button class="public-toggle-button" id="memDetailReplyList-orderBtn-delYn">삭제여부</button>
 					<button class="public-toggle-button" id="memDetailReplyList-orderBtn-date">작성일자</button>
+					<select class="public-toggle-select" id="memDetailReplySortOrder">
+						<option value="asc">오름차순</option>
+						<option value="desc">내림차순</option>
+					</select>
 				</div>
 				<table class="userDetailTable" id="userDetailTable-memDetailReplyList">
 					<thead>

--- a/src/main/webapp/WEB-INF/views/admin/umg/memberManagement.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/umg/memberManagement.jsp
@@ -3,7 +3,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 <script src="/js/include/admin/umg/memberManagement.js"></script>
 <h2 style="color: gray; font-size: 18px; margin: 0; line-height: 75px;">회원 관리</h2>
-<input type="hidden" id="comCalendarInput" />
+<input type="hidden" id="comCalendarInput" style="display: none;"/>
 <div class="member-1 flex gap">
 	<div class="template-panel public-countCard">
 		<div class="public-card-title">일일 사용자 현황</div>
@@ -321,30 +321,23 @@
 	<div class="template-panel" style="width: 792.5px;">
 		<div class="middleTitle">사용자 접속 통계</div>
 		<div class="btn-group flex gap5 userOnlineChart">
-		<input type="hidden" id="userOnlineChartStartDay" />
-		<input type="hidden" id="userOnlineChartEndDay" />
-		<select class="public-toggle-select" name="userOnlineChartDay" id="userOnlineChartDay">
-			<option value="daily">일별</option>
-			<option value="monthly">월별</option>
-			<option value="selectDays">기간선택</option>
-		</select>
-		<select class="public-toggle-select" name="userOnlineChartGender" id="userOnlineChartGender">
-			<option value="">성별전체</option>
-			<option value="male">남자</option>
-			<option value="female">여자</option>
-		</select>
-		<select class="public-toggle-select" name="userOnlineChartAgeGroup" id="userOnlineChartAgeGroup">
-			<option value="">성별전체</option>
-			<option value="male">남자</option>
-			<option value="female">여자</option>
-		</select>
-			<button class="public-toggle-button active" id="userOnlineChartDayBtn">일별</button>
-			<button class="public-toggle-button" id="userOnlineChartMonthBtn">월별</button>
-			<button class="public-toggle-button" id="userOnlineChartMaleBtn">남성</button>
-			<button class="public-toggle-button" id="userOnlineChartFemaleBtn">여성</button>
-			<button class="public-toggle-button" id="userOnlineChartCalender">
-				<img alt="" src="/images/admin/admin-calender.png">
-			</button>
+			<input type="hidden" id="userOnlineChartStartDay" />
+			<input type="hidden" id="userOnlineChartEndDay" />
+			<select class="public-toggle-select" name="userOnlineChartDay" id="userOnlineChartDay">
+				<option value="daily">일별</option>
+				<option value="monthly">월별</option>
+				<option value="selectDays">기간선택</option>
+			</select>
+			<select class="public-toggle-select" name="userOnlineChartGender" id="userOnlineChartGender">
+				<option value="">성별전체</option>
+				<option value="male">남자</option>
+				<option value="female">여자</option>
+			</select>
+			<select class="public-toggle-select" name="userOnlineChartAgeGroup" id="userOnlineChartAgeGroup">
+				<option value="">연령전체</option>
+				<option value="teen">청소년</option>
+				<option value="youth">청년</option>
+			</select>
 		</div>
 		<div style="height: 500px; margin-top: auto;">
 			<canvas id="userOnlineChartCanvas"></canvas>
@@ -353,13 +346,23 @@
 	<div class="template-panel" style="width: 792.5px;">
 		<div class="middleTitle">페이지별 방문자 수</div>
 		<div class="btn-group flex gap5 pageVisitChart">
-			<button class="public-toggle-button active" id="pageVisitChartDayBtn">일별</button>
-			<button class="public-toggle-button" id="pageVisitChartMonthBtn">월별</button>
-			<button class="public-toggle-button" id="pageVisitChartMaleBtn">남성</button>
-			<button class="public-toggle-button" id="pageVisitChartFemaleBtn">여성</button>
-			<button class="public-toggle-button" id="pageVisitChartCalender">
-				<img alt="" src="/images/admin/admin-calender.png">
-			</button>
+			<input type="hidden" id="pageVisitChartStartDay" />
+			<input type="hidden" id="pageVisitChartEndDay" />
+			<select class="public-toggle-select" name="pageVisitChartDay" id="pageVisitChartDay">
+				<option value="monthly">월간</option>
+				<option value="daily">일간</option>
+				<option value="selectDays">기간선택</option>
+			</select>
+			<select class="public-toggle-select" name="pageVisitChartGender" id="pageVisitChartGender">
+				<option value="">성별전체</option>
+				<option value="male">남자</option>
+				<option value="female">여자</option>
+			</select>
+			<select class="public-toggle-select" name="pageVisitChartAgeGroup" id="pageVisitChartAgeGroup">
+				<option value="">연령전체</option>
+				<option value="teen">청소년</option>
+				<option value="youth">청년</option>
+			</select>
 		</div>
 		<div style="height: 500px; margin-top: auto;">
 			<canvas id="pageVisitChartCanvas"></canvas>


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 사용자 접속통계 셀렉트박스로 처리
- 페이지별 방문자 수 셀렉트박스로 처리
- 사용자조회 오름,내림차순 정렬 셀렉트박스로 처리
- 회원 게시글 오름,내림차순 정렬 셀렉트박스로 처리
- 회원 댓글 오름,내림차순 정렬 셀렉트박스로 처리

## 스크린샷
### 오름차순, 내림차순 셀렉트 값 유지 한채로 조회. 오름,내림차순 셀렉트 변경시 왼쪽 선택된 값 유지 한채로 조회.
<img width="1601" height="754" alt="image" src="https://github.com/user-attachments/assets/46c11ec0-e5ee-4155-aca2-af3857c85756" />

### 기간 선택 시 달력 출력
<img width="1552" height="751" alt="image" src="https://github.com/user-attachments/assets/d5b0975e-99fa-43cf-8431-fa1cce61a472" />
<img width="1010" height="618" alt="image" src="https://github.com/user-attachments/assets/1f16a33a-7b40-4b56-9005-88d75c4c12e8" />

## 주의사항
- 달력에서 기간 선택을 하는게 일별, 월별과 통합되는 방향으로 설계됨
- 셀렉트 박스 change에 이벤트가 걸려있어서 기간선택한번하고 다시 기간선택하려면 다른걸로 갔다와야함.
- 페이지별 방문자 수는 쿼리가 오늘 혹은 현재월로 조회되어있어서 문구를 일간,월간 변경했고 월간 먼저 출력되도록 설정해둠

Closes #221 
