### PR TITLE
[feat] 관리자 페이지 차트 다운로드 및 페이징 처리

### DIFF
--- a/src/main/java/kr/or/ddit/admin/cmg/service/impl/ContentsManagementServiceImpl.java
+++ b/src/main/java/kr/or/ddit/admin/cmg/service/impl/ContentsManagementServiceImpl.java
@@ -33,7 +33,7 @@ public class ContentsManagementServiceImpl implements ContentsManagementService 
 		int total = contentsManagementMapper.getAllEntList(companyVO);
 
 		return new ArticlePage<CompanyVO>(total, companyVO.getCurrentPage(), companyVO.getSize(), companyList,
-				companyVO.getKeyword());
+				companyVO.getKeyword(),10);
 	}
 
 	@Override
@@ -58,7 +58,7 @@ public class ContentsManagementServiceImpl implements ContentsManagementService 
 		
 		int total = contentsManagementMapper.selectReviewListTotal(interviewReviewVO);
 		
-		ArticlePage<InterviewReviewVO> articlePage = new ArticlePage<>(total, interviewReviewVO.getCurrentPage(), interviewReviewVO.getSize(), interviewReviewList, interviewReviewVO.getKeyword());
+		ArticlePage<InterviewReviewVO> articlePage = new ArticlePage<>(total, interviewReviewVO.getCurrentPage(), interviewReviewVO.getSize(), interviewReviewList, interviewReviewVO.getKeyword(),10);
 		
 		return articlePage;
 	}

--- a/src/main/java/kr/or/ddit/admin/cmg/web/ContentsManagementController.java
+++ b/src/main/java/kr/or/ddit/admin/cmg/web/ContentsManagementController.java
@@ -119,7 +119,7 @@ public class ContentsManagementController {
 		List<ComCodeVO> contestTargetList = contestService.getContestTargetList();
 		List<ComCodeVO> contestTypeList = contestService.getContestTypeList();
 		
-		ArticlePage<ActivityVO> articlePage = new ArticlePage<>(total, currentPage, 6, activityList, keyword);
+		ArticlePage<ActivityVO> articlePage = new ArticlePage<>(total, currentPage, 6, activityList, keyword,10);
 		response.put("success", true);
 		response.put("contestTargetList", contestTargetList);
 		response.put("articlePage", articlePage);
@@ -183,7 +183,7 @@ public class ContentsManagementController {
 		int total = contestService.selectCttCount(contestVO);
 		List<ComCodeVO> contestTypeList = contestService.getContestTypeList();
 		List<ComCodeVO> contestTargetList = contestService.getContestTargetList();
-		ArticlePage<ContestVO> articlePage = new ArticlePage<>(total, currentPage, size, contestList, keyword);
+		ArticlePage<ContestVO> articlePage = new ArticlePage<>(total, currentPage, size, contestList, keyword,10);
 
 		response.put("success", true);
 		response.put("contestTypeList", contestTypeList);

--- a/src/main/java/kr/or/ddit/admin/csmg/service/impl/CounselManagementServiceImpl.java
+++ b/src/main/java/kr/or/ddit/admin/csmg/service/impl/CounselManagementServiceImpl.java
@@ -89,7 +89,7 @@ public class CounselManagementServiceImpl implements CounselManagementService {
 		int total = counselManagementMapper.selectCounselorStatTotalCount(map);
 		List<Map<String, Object>> counselorStatList = counselManagementMapper.selectCounselorStatList(map);
 		
-		ArticlePage<Map<String, Object>> articlePage = new ArticlePage<>(total, currentPage, size, counselorStatList, keyword);
+		ArticlePage<Map<String, Object>> articlePage = new ArticlePage<>(total, currentPage, size, counselorStatList, keyword,10);
 		
 		return articlePage;
 	}
@@ -119,7 +119,7 @@ public class CounselManagementServiceImpl implements CounselManagementService {
 		int total = counselManagementMapper.selectCounselingListTotalCount(map);
 		List<Map<String, Object>> counselingList = counselManagementMapper.selectCounselingList(map);
 		
-		ArticlePage<Map<String, Object>> articlePage = new ArticlePage<>(total, currentPage, size, counselingList, null);
+		ArticlePage<Map<String, Object>> articlePage = new ArticlePage<>(total, currentPage, size, counselingList, null,10);
 		
 		return articlePage;
 	}

--- a/src/main/java/kr/or/ddit/admin/umg/service/impl/UserManagementServiceImpl.java
+++ b/src/main/java/kr/or/ddit/admin/umg/service/impl/UserManagementServiceImpl.java
@@ -60,7 +60,7 @@ public class UserManagementServiceImpl implements UserManagementService {
 		// 건수
 		int total = userManagementMapper.getAlluserList(map);
 		// 페이지 네이션
-		ArticlePage<MemberVO> articlePage = new ArticlePage<MemberVO>(total, currentPage, size, list, keyword);
+		ArticlePage<MemberVO> articlePage = new ArticlePage<MemberVO>(total, currentPage, size, list, keyword,10);
 
 		return articlePage;
 	}
@@ -197,7 +197,7 @@ public class UserManagementServiceImpl implements UserManagementService {
 		// 건수
 		int total = userManagementMapper.getAllReportList(map);
 //		// 페이지 네이션
-		ArticlePage<ReportVO> articlePage = new ArticlePage<ReportVO>(total, currentPage, size, list, keyword);
+		ArticlePage<ReportVO> articlePage = new ArticlePage<ReportVO>(total, currentPage, size, list, keyword,10);
 
 		return articlePage;
 	}
@@ -247,7 +247,7 @@ public class UserManagementServiceImpl implements UserManagementService {
 	    int total = userManagementMapper.getAllMemberPenaltyList(map);
 	    // 페이지 네이션
 	    ArticlePage<MemberPenaltyVO> articlePage = new ArticlePage<MemberPenaltyVO>(total, currentPage, size,
-	            penaltyVOList, keyword);
+	            penaltyVOList, keyword,10);
 
 	    return articlePage;
 	}
@@ -430,7 +430,7 @@ public class UserManagementServiceImpl implements UserManagementService {
 		List<MemberVO> list = userManagementMapper.getMemberActivityList(map);
 		int total = userManagementMapper.getAllMemberActivityList(map);
 
-		ArticlePage<MemberVO> articlePage = new ArticlePage<>(total, currentPage, size, list, keyword);
+		ArticlePage<MemberVO> articlePage = new ArticlePage<>(total, currentPage, size, list, keyword,10);
 
 		return articlePage;
 	}
@@ -453,7 +453,7 @@ public class UserManagementServiceImpl implements UserManagementService {
 		List<CommBoardVO> list = userManagementMapper.getMemberDetailBoardList(map);
 		int total = userManagementMapper.selectBoardCountByMemId(map);
 
-		ArticlePage<CommBoardVO> articlePage = new ArticlePage<>(total, currentPage, size, list, "");
+		ArticlePage<CommBoardVO> articlePage = new ArticlePage<>(total, currentPage, size, list, "",10);
 
 		return articlePage;
 	}
@@ -476,7 +476,7 @@ public class UserManagementServiceImpl implements UserManagementService {
 		List<CommReplyVO> list = userManagementMapper.getMemberDetailReplyList(map);
 		int total = userManagementMapper.selectReplyCountByMemId(map);
 
-		ArticlePage<CommReplyVO> articlePage = new ArticlePage<>(total, currentPage, size, list, "");
+		ArticlePage<CommReplyVO> articlePage = new ArticlePage<>(total, currentPage, size, list, "",10);
 
 		return articlePage;
 	}
@@ -499,7 +499,7 @@ public class UserManagementServiceImpl implements UserManagementService {
 		List<PageLogVO> list = userManagementMapper.getMemberPageLogList(map);
 		int total = userManagementMapper.getAllMemberPageLogList(map);
 
-		return new ArticlePage<>(total, currentPage, size, list, keyword);
+		return new ArticlePage<>(total, currentPage, size, list, keyword,10);
 
 	}
 

--- a/src/main/java/kr/or/ddit/csc/faq/service/impl/FaqServiceImpl.java
+++ b/src/main/java/kr/or/ddit/csc/faq/service/impl/FaqServiceImpl.java
@@ -63,7 +63,7 @@ public class FaqServiceImpl implements FaqService{
 		// 건수
 		int total = faqMapper.getAllFaq(map);
 		// 페이지 네이션
-		ArticlePage<FaqVO> articlePage = new ArticlePage<FaqVO>(total, currentPage, size, list, keyword);
+		ArticlePage<FaqVO> articlePage = new ArticlePage<FaqVO>(total, currentPage, size, list, keyword,10);
 		articlePage.setUrl("/csc/admin/faqList.do");
 		return articlePage;
 	}

--- a/src/main/java/kr/or/ddit/csc/inq/service/impl/InqServiceimpl.java
+++ b/src/main/java/kr/or/ddit/csc/inq/service/impl/InqServiceimpl.java
@@ -86,7 +86,7 @@ public class InqServiceimpl implements InqService {
 		// 건수
 		int total = inqMapper.getAllInq(map);
 		// 페이지 네이션
-		ArticlePage<InqVO> articlePage = new ArticlePage<InqVO>(total, currentPage, size, list, keyword);
+		ArticlePage<InqVO> articlePage = new ArticlePage<InqVO>(total, currentPage, size, list, keyword,10);
 		articlePage.setUrl("/csc/admin/faqList.do");
 		return articlePage;
 	}

--- a/src/main/java/kr/or/ddit/csc/not/service/impl/NoticeServiceImpl.java
+++ b/src/main/java/kr/or/ddit/csc/not/service/impl/NoticeServiceImpl.java
@@ -81,7 +81,7 @@ public class NoticeServiceImpl implements NoticeService {
 		// 건수
 		int total = noticeMapper.getAllNotice(map);
 		// 페이지 네이션
-		ArticlePage<NoticeVO> articlePage = new ArticlePage<>(total, currentPage, size, list, keyword);
+		ArticlePage<NoticeVO> articlePage = new ArticlePage<>(total, currentPage, size, list, keyword,10);
 		articlePage.setUrl("/csc/admin/noticeList.do");
 		return articlePage;
 	}

--- a/src/main/java/kr/or/ddit/ertds/univ/uvsrch/service/impl/UniversityManageServiceImpl.java
+++ b/src/main/java/kr/or/ddit/ertds/univ/uvsrch/service/impl/UniversityManageServiceImpl.java
@@ -26,7 +26,7 @@ public class UniversityManageServiceImpl implements UniversityManageService {
 	    int total = universityMapper.selectUniversityTotalCount(universityVO);
 	    
 	    return new ArticlePage<UniversityVO>(total, universityVO.getCurrentPage(), universityVO.getSize(), universityList,
-	            universityVO.getKeyword());
+	            universityVO.getKeyword(),10);
 	}
 
 	@Override

--- a/src/main/java/kr/or/ddit/util/ArticlePage.java
+++ b/src/main/java/kr/or/ddit/util/ArticlePage.java
@@ -2,6 +2,7 @@ package kr.or.ddit.util;
 
 import java.util.List;
 
+import kr.or.ddit.main.service.MemberVO;
 import lombok.Data;
 
 //페이징 관련 정보 + 게시글 정보
@@ -25,6 +26,9 @@ public class ArticlePage<T> {
 	private List<T> content;
 	//페이징 처리
 	private String pagingArea = "";
+	//보여줄 페이징 갯수 defalut =5;
+	private int blockSize = 5;
+	
 	
 	//생성자(Constructor) : 페이징 객체 생성
 	public ArticlePage(int total, int currentPage, int size
@@ -34,7 +38,6 @@ public class ArticlePage<T> {
 		this.currentPage = currentPage;
 		this.keyword = keyword;
 		this.content = content;
-		
 		//전체 글 수가 0이면?
 		if(total==0) {
 			this.totalPages = 0;//전체 페이지 수
@@ -51,15 +54,15 @@ public class ArticlePage<T> {
 			
 			//페이지 블록시작번호를 구하는 공식
 			// 블록시작번호 = 현재페이지 / 블록크기 * 블록크기 + 1
-			this.startPage = currentPage / 5 * 5 + 1;
+			 this.startPage = currentPage / blockSize * blockSize + 1;
 			//현재페이지 % 블록크기 => 0일 때 보정
-			if(currentPage % 5 == 0) {
-				this.startPage -= 5;
+			if(currentPage % blockSize == 0) {
+				this.startPage -= blockSize;
 			}
 			
 			//블록종료번호 = 블록시작번호 + (블록크기 - 1)
 			//[1][2][3][4][5][다음]
-			this.endPage = this.startPage + (5 - 1);
+			this.endPage = this.startPage + (blockSize - 1);
 			
 			//블록종료번호 > 전체페이지수
 			if(this.endPage > this.totalPages) {
@@ -76,7 +79,7 @@ public class ArticlePage<T> {
 		}
 		pagingArea += "'";
 		pagingArea += "id='example2_previous'>";
-		pagingArea += "<a href='"+this.url+"?currentPage="+(this.startPage-5)+"&keyword="+this.keyword+"' aria-controls='example2' data-dt-idx='0' tabindex='0' ";
+		pagingArea += "<a href='"+this.url+"?currentPage="+(this.startPage-blockSize)+"&keyword="+this.keyword+"' aria-controls='example2' data-dt-idx='0' tabindex='0' ";
 		pagingArea += "class='page-link'>Previous</a></li>";
 		
 		for(int pNo=this.startPage;pNo<=this.endPage;pNo++) {		
@@ -94,13 +97,89 @@ public class ArticlePage<T> {
 			pagingArea += "disabled";
 		}
 		pagingArea += "' id='example2_next'><a ";
-		pagingArea += "href='"+this.url+"?currentPage="+(this.startPage+5)+"&keyword="+this.keyword+"' aria-controls='example2' data-dt-idx='7' ";
+		pagingArea += "href='"+this.url+"?currentPage="+(this.startPage+blockSize)+"&keyword="+this.keyword+"' aria-controls='example2' data-dt-idx='7' ";
 		pagingArea += "tabindex='0' class='page-link'>Next</a></li>";
 		pagingArea += "</ul>";
 		pagingArea += "</div>";
 		pagingArea += "</div>";
-	}//end ArticlePage
-	
+	}
+
+
+	//생성자(Constructor) : 페이징 객체 생성
+		public ArticlePage(int total, int currentPage, int size
+					,List<T> content, String keyword,int blockSize) {
+			//size : 한 화면에 보여질 목록의 행 수
+			this.total = total;
+			this.currentPage = currentPage;
+			this.keyword = keyword;
+			this.content = content;
+			this.blockSize=blockSize;
+			//전체 글 수가 0이면?
+			if(total==0) {
+				this.totalPages = 0;//전체 페이지 수
+				this.startPage = 0;//블록 시작번호
+				this.endPage = 0;//블록 종료번호
+				this.blockSize = blockSize;
+			}else {//글이 있다면?
+				//전체 페이지 수 = 전체글 수 / 한 화면에 보여질 목록의 행 수
+				//3 = 31 / 10
+				this.totalPages = total / size; //3페이지
+				//나머지가 있다면, 페이지를 1 증가
+				if(total % size > 0) {//ex) 나머지 1
+					this.totalPages++;//4페이지
+				}
+				
+				//페이지 블록시작번호를 구하는 공식
+				// 블록시작번호 = 현재페이지 / 블록크기 * 블록크기 + 1
+				 this.startPage = currentPage / blockSize * blockSize + 1;
+				//현재페이지 % 블록크기 => 0일 때 보정
+				if(currentPage % blockSize == 0) {
+					this.startPage -= blockSize;
+				}
+				
+				//블록종료번호 = 블록시작번호 + (블록크기 - 1)
+				//[1][2][3][4][5][다음]
+				this.endPage = this.startPage + (blockSize - 1);
+				
+				//블록종료번호 > 전체페이지수
+				if(this.endPage > this.totalPages) {
+					this.endPage = this.totalPages;
+				}
+			}
+			
+			pagingArea += "<div class='col-sm-12 col-md-7'>";
+			pagingArea += "<div class='dataTables_paginate paging_simple_numbers' id='example2_paginate'>";
+			pagingArea += "<ul class='pagination'>";
+			pagingArea += "<li class='paginate_button page-item previous "; 
+			if(this.startPage<6) {
+				pagingArea += "disabled ";
+			}
+			pagingArea += "'";
+			pagingArea += "id='example2_previous'>";
+			pagingArea += "<a href='"+this.url+"?currentPage="+(this.startPage-blockSize)+"&keyword="+this.keyword+"' aria-controls='example2' data-dt-idx='0' tabindex='0' ";
+			pagingArea += "class='page-link'>Previous</a></li>";
+			
+			for(int pNo=this.startPage;pNo<=this.endPage;pNo++) {		
+			pagingArea += "<li class='paginate_button page-item ";
+				if(this.currentPage == pNo) {
+					pagingArea += "active";
+				}
+				pagingArea += "'>";
+				pagingArea += "<a href='"+this.url+"?currentPage="+pNo+"&keyword="+this.keyword+"' aria-controls='example2' data-dt-idx='1' tabindex='0' ";
+				pagingArea += "class='page-link'>"+pNo+"</a>";
+				pagingArea += "</li>";
+			}
+			pagingArea += "<li class='paginate_button page-item next "; 
+			if(this.endPage>=this.totalPages) {
+				pagingArea += "disabled";
+			}
+			pagingArea += "' id='example2_next'><a ";
+			pagingArea += "href='"+this.url+"?currentPage="+(this.startPage+blockSize)+"&keyword="+this.keyword+"' aria-controls='example2' data-dt-idx='7' ";
+			pagingArea += "tabindex='0' class='page-link'>Next</a></li>";
+			pagingArea += "</ul>";
+			pagingArea += "</div>";
+			pagingArea += "</div>";
+		}
 	
 }
 

--- a/src/main/resources/static/css/admin/admDashboard.css
+++ b/src/main/resources/static/css/admin/admDashboard.css
@@ -106,6 +106,27 @@ to {
 	font-size: 14px;
 	margin: 0;
 	font-weight: 600;
+    display: flex;
+    justify-content: space-between;
+}
+
+.middleTitleBtn {
+	min-width: 45.77px;
+	height: 30px;
+	font-size: 12px;
+	font-weight: bold;
+	border: none;
+	border-radius: 2px;
+	cursor: pointer;
+	transition: background-color 0.3s ease, color 0.3s ease;
+	padding: 7px 10px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: fit-content;
+	line-height: 1;
+	color: white;
+	background-color: #727cf5;
 }
 
 .filter-box {

--- a/src/main/resources/static/js/include/admin/dashboard.js
+++ b/src/main/resources/static/js/include/admin/dashboard.js
@@ -2,6 +2,15 @@ let doughnutChart = null;
 
 document.addEventListener('DOMContentLoaded', function() {
 
+	/************************ PNG 다운로드 *******************************/
+	let monthPng = document.getElementById("monthPng");
+	function downloadCanvas(chart, filename, mime='image/png') {
+	  const link = document.createElement('a');
+	  link.href = chart.toBase64Image(mime); // Chart.js 내장
+	  link.download = filename;
+	  link.click();
+	}
+
 	/************************ 월별 사용자 통계 및 카드 데이터 *******************************/
 	axios.get('/admin/chart/getAdminDashboard.do').then(res => {
 		const chartData = res.data;
@@ -48,8 +57,9 @@ document.addEventListener('DOMContentLoaded', function() {
 		const secessionUsersData = chartData.secessionChart.map(item => item.MONTHLY_DELETION_COUNT);
 		const monthLabels = chartData.monthlyChart.map(item => item.MONTH + '월');
 		const ctxUser = document.getElementById('lineChart');
+		
 		if (ctxUser) {
-			new Chart(ctxUser, {
+			 newChart = new Chart(ctxUser, {
 				type: 'line',
 				data: {
 					labels: monthLabels,
@@ -115,7 +125,9 @@ document.addEventListener('DOMContentLoaded', function() {
 			});
 		}
 	});
-
+	document.getElementById('monthPng').onclick = () =>{
+	    downloadCanvas(newChart, '월별이용자통계.png', 'image/png');
+	}
 	/********************* 결제/구독 통계 *******************************/
 	axios.get('/admin/las/payment/monthly-users').then(res => {
 		const responseData = res.data;
@@ -124,7 +136,7 @@ document.addEventListener('DOMContentLoaded', function() {
 		const subscriberData = responseData.map(item => item.subscribers);
 		const ctxPayment = document.getElementById('revenueChart')?.getContext('2d');
 		if (ctxPayment) {
-			new Chart(ctxPayment, {
+			newMoneyChart= new Chart(ctxPayment, {
 				type: 'line',
 				data: {
 					labels: labels,
@@ -174,11 +186,12 @@ document.addEventListener('DOMContentLoaded', function() {
 			});
 		}
 	});
-
+	document.getElementById('moneyPng').onclick = () =>{
+	    downloadCanvas(newMoneyChart, '결제/구독 통계.png', 'image/png');
+	}
 	/********************* 컨텐츠 이용 통계 (도넛) *******************************/
 	const youthBtn = document.getElementById('youthBtn');
 	const teenBtn = document.getElementById('teenBtn');
-
 	function updateDoughnutChart(param) {
 		const ctxDoughnut = document.getElementById('nestedDoughnutChart');
 		if (!ctxDoughnut) return;
@@ -210,6 +223,7 @@ document.addEventListener('DOMContentLoaded', function() {
 						hoverOffset: 20
 					}]
 				},
+				plugins: [ChartDataLabels],
 				options: {
 					responsive: true,
 					maintainAspectRatio: false,
@@ -220,6 +234,18 @@ document.addEventListener('DOMContentLoaded', function() {
 							display: true,
 							position: 'bottom',
 							labels: { color: '#555', padding: 25, font: { size: 14 } }
+						}, 
+						datalabels: {
+							formatter: (value, ctx) => {
+								const sum = ctx.chart.data.datasets[0].data.reduce((a, b) => a + b, 0);
+								const pct = (value / sum * 100).toFixed(0) ;
+								if(pct <3){
+									return null;
+								}
+								return pct+'%';
+							},
+							color: '#fff',
+							font: { weight: 'bold' }
 						}
 					}
 				}

--- a/src/main/resources/static/js/include/admin/dashboard.js
+++ b/src/main/resources/static/js/include/admin/dashboard.js
@@ -301,7 +301,9 @@ document.addEventListener('DOMContentLoaded', function() {
 		setActiveButton(this);
 	});
 
-
+	document.getElementById('contentBtn').onclick = () =>{
+	    downloadCanvas(newMoneyChart, '컨텐츠 이용 통계.png', 'image/png');
+	}
 
 });
 

--- a/src/main/resources/static/js/include/admin/umg/counselorManagement.js
+++ b/src/main/resources/static/js/include/admin/umg/counselorManagement.js
@@ -748,7 +748,7 @@ function counselorManagement() {
 			const purplePalette = [
 				'#B8A5F5', '#8A6BEF', '#6C4DDC'
 			];
-			// 막대 차트 생성
+			// 도넛 차트 생성
 			window.consultMethodStatisticsChartInstance = new Chart(ctx, {
 				type: 'doughnut',
 				data: {
@@ -762,16 +762,30 @@ function counselorManagement() {
 						hoverOffset: 20
 					}]
 				},
+				plugins: [ChartDataLabels],
 				options: {
 					responsive: true,
 					maintainAspectRatio: false,
 					cutout: '60%',
 					layout: { padding: { top: 25, bottom: 25, left: 25, right: 25 } },
+
 					plugins: {
 						legend: { display: true, position: 'bottom' },
 						title: {
 							display: !!rangeTitle,
 							text: rangeTitle ? [rangeTitle] : []
+						},
+						datalabels: {
+							formatter: (value, ctx) => {
+								const sum = ctx.chart.data.datasets[0].data.reduce((a, b) => a + b, 0);
+								const pct = (value / sum * 100).toFixed(0) ;
+								if(pct <3){
+									return null;
+								}
+								return pct+'%';
+							},
+							color: '#fff',
+							font: { weight: 'bold' }
 						}
 					},
 				}

--- a/src/main/resources/static/js/include/admin/umg/memberManagement.js
+++ b/src/main/resources/static/js/include/admin/umg/memberManagement.js
@@ -329,7 +329,7 @@ function memberManagement() {
 	function fetchUserList(page = 1, sortBy = 'id', sortOrder = 'asc', inFilter = '') {
 		currentPage = page;
 
-		const pageSize = 10;
+		const pageSize = 5;
 		const keyword = document.querySelector('input[name="keyword"]').value;
 		const status = document.querySelector('select[name="status"]').value;
 		// fetchUserList 함수 내에서 userListStatus의 최신 값을 가져오도록 수정

--- a/src/main/resources/static/js/include/admin/umg/sanctionsDescription.js
+++ b/src/main/resources/static/js/include/admin/umg/sanctionsDescription.js
@@ -101,6 +101,7 @@ function sanctionsDescription() {
 			const config = {
 				type: 'doughnut',
 				data: data,
+				plugins: [ChartDataLabels],
 				options: {
 					responsive: true,
 					layout: {
@@ -126,6 +127,16 @@ function sanctionsDescription() {
 									return label;
 								}
 							}
+						},
+						datalabels: {
+							formatter: (value, ctx) => {
+								const sum = ctx.chart.data.datasets[0].data.reduce((a, b) => a + b, 0);
+								const pct = (value / sum * 100).toFixed(0) ;
+
+								return pct+'%';
+							},
+							color: '#fff',
+							font: { weight: 'bold' }
 						}
 					}
 				}

--- a/src/main/webapp/WEB-INF/views/admin/dashboard.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/dashboard.jsp
@@ -42,7 +42,12 @@
 					</div>
 				</div>
 				<div class="template-panel dashboard-1-2 overflow-wrap">
-					<div class="middleTitle">월별 이용자 통계</div>
+					<div class="middleTitle">
+						<div>월별 이용자 통계</div>
+						<div>
+							<button class="middleTitleBtn" id="monthPng">다운로드</button>
+						</div>
+					</div>
 					<div style="width: 100%; height: 100%; margin-top: 15px;">
 						<canvas id="lineChart"></canvas>
 					</div>
@@ -50,7 +55,12 @@
 			</div>
 			<div class="dash2Flex">
 				<div class="template-panel dashboard-2 overflow-wrap">
-					<div class="middleTitle">결제/구독 통계</div>
+					<div class="middleTitle">
+						결제/구독 통계
+						<div>
+							<button class="middleTitleBtn" id="moneyPng">다운로드</button>
+						</div>
+					</div>
 					<div class="dashboard-2-1">
 
 						<div class="stat-item">

--- a/src/main/webapp/WEB-INF/views/admin/dashboard.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/dashboard.jsp
@@ -89,6 +89,7 @@
 					<div class="flex gap10 endflex btn-group">
 						<button class="public-toggle-button active" id="teenBtn">청소년</button>
 						<button class="public-toggle-button" id="youthBtn">청년</button>
+						<button class="public-toggle-button" id="contentBtn">다운로드</button>
 					</div>
 					<div class="chart-container-doughnut">
 						<canvas id="nestedDoughnutChart"></canvas>

--- a/src/main/webapp/WEB-INF/views/include/admin/sidebar.jsp
+++ b/src/main/webapp/WEB-INF/views/include/admin/sidebar.jsp
@@ -11,6 +11,8 @@
 <script src="/ckeditor5/ckeditor.js"></script>
 <script src="/js/chart/chart.umd.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
+
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
1. 페이징 처리
-> articlePage를 오버로드하여 관리자 페이지에서 10개 나오도록 수정 
2. 도넛 차트 숫자 표기
-> 기존 bar차트까지 수정하기로 하였으나, 오전 회의시간에 도넛차트만 표기하기로 결정
3. 관리자 메인 데시보드 차트 다운로드
-> 월별 사용자 통계 , 결제/구독 통계, 컨텐츠 이용 통계 다운로드 구현
## 스크린샷
<img width="1454" height="723" alt="image" src="https://github.com/user-attachments/assets/155e3528-5db2-4bad-a614-38047e0e942b" />
<img width="156" height="114" alt="image" src="https://github.com/user-attachments/assets/61176804-fd37-4c92-872b-4341ad287589" />
<img width="765" height="438" alt="image" src="https://github.com/user-attachments/assets/e6623d3e-e69e-434d-9c12-9b7bfbbd7dca" />
<img width="452" height="409" alt="image" src="https://github.com/user-attachments/assets/22c728e4-5dd2-4d0f-b6aa-2541cfe761b1" />

## 주의사항

Closes #265 
