### PR TITLE
[Feat] 사용자 화면 브레드 크럼 및 본인인증, 마이페이지 번호변경 추가

### DIFF
--- a/src/main/java/kr/or/ddit/account/join/service/MemberJoinService.java
+++ b/src/main/java/kr/or/ddit/account/join/service/MemberJoinService.java
@@ -1,5 +1,7 @@
 package kr.or.ddit.account.join.service;
 
+import java.util.Map;
+
 import kr.or.ddit.main.service.MemberVO;
 
 public interface MemberJoinService {
@@ -7,5 +9,9 @@ public interface MemberJoinService {
 	MemberVO selectUserEmail(String email);
 
 	boolean isNicknameExists(String nickname);
+
+	Map<String, Object> identityCheck(String imp_uid);
+
+	void memberJoin(MemberVO memberVO);
 
 }

--- a/src/main/java/kr/or/ddit/account/join/service/MemberJoinService.java
+++ b/src/main/java/kr/or/ddit/account/join/service/MemberJoinService.java
@@ -12,6 +12,6 @@ public interface MemberJoinService {
 
 	Map<String, Object> identityCheck(String imp_uid);
 
-	void memberJoin(MemberVO memberVO);
+	int memberJoin(MemberVO memberVO);
 
 }

--- a/src/main/java/kr/or/ddit/account/join/service/MemberJoinService.java
+++ b/src/main/java/kr/or/ddit/account/join/service/MemberJoinService.java
@@ -13,5 +13,6 @@ public interface MemberJoinService {
 	Map<String, Object> identityCheck(String imp_uid);
 
 	int memberJoin(MemberVO memberVO);
-
+	
+	String formatPhoneNumber(String phoneNum);
 }

--- a/src/main/java/kr/or/ddit/account/join/service/impl/MemberJoinMapper.java
+++ b/src/main/java/kr/or/ddit/account/join/service/impl/MemberJoinMapper.java
@@ -11,4 +11,6 @@ public interface MemberJoinMapper {
 
 	String isNicknameExists(String nickname);
 
+	int memberJoin(MemberVO memberVO);
+
 }

--- a/src/main/java/kr/or/ddit/account/join/service/impl/MemberJoinServiceImpl.java
+++ b/src/main/java/kr/or/ddit/account/join/service/impl/MemberJoinServiceImpl.java
@@ -1,16 +1,35 @@
 package kr.or.ddit.account.join.service.impl;
 
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.google.gson.Gson;
 
 import kr.or.ddit.account.join.service.MemberJoinService;
 import kr.or.ddit.main.service.MemberVO;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
-public class MemberJoinServiceImpl implements MemberJoinService{
+@Slf4j
+public class MemberJoinServiceImpl implements MemberJoinService {
 
 	@Autowired
 	MemberJoinMapper memberJoinMapper;
+	@Value("${imp.identity.key}")
+	private String IMP_IDENTITY_KEY;
+	@Value("${imp.identity.secret}")
+	private String IMP_IDENTITY_SECRET;
 	
 	@Override
 	public MemberVO selectUserEmail(String email) {
@@ -21,14 +40,89 @@ public class MemberJoinServiceImpl implements MemberJoinService{
 	@Override
 	public boolean isNicknameExists(String nickname) {
 		String result = this.memberJoinMapper.isNicknameExists(nickname);
-		
+
 		boolean tf = true;
-		
-		if(result.equals("false")) {
-			tf=false;
+
+		if (result.equals("false")) {
+			tf = false;
 		}
-		
+
 		return tf;
+	}
+
+	@Override
+	public Map<String, Object> identityCheck(String imp_uid) {
+
+		log.info("imp_uid : @@@@@" + imp_uid);
+
+		if (imp_uid == null || imp_uid.isEmpty()) {
+			Map<String, Object> result = new HashMap<>();
+			result.put("success", false);
+			result.put("message", "imp_uid가 누락되었습니다.");
+			return result;
+		}
+
+		RestTemplate restTemplate = new RestTemplate();
+
+		// 1. 인증 토큰 발급
+		String tokenUrl = "https://api.iamport.kr/users/getToken";
+
+		HttpHeaders tokenHeaders = new HttpHeaders();
+		tokenHeaders.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+		Map<String, String> tokenBody = new HashMap<>();
+		tokenBody.put("imp_key", IMP_IDENTITY_KEY); // REST API 키
+		tokenBody.put("imp_secret", IMP_IDENTITY_SECRET);
+		
+		Gson gson = new Gson();
+		String jsonBody = gson.toJson(tokenBody);
+		
+		String accessToken = "";
+		try {
+			HttpEntity<String> tokenRequest = new HttpEntity<>(jsonBody, tokenHeaders);
+
+			ResponseEntity<Map> tokenResponse = restTemplate.exchange(tokenUrl, HttpMethod.POST, tokenRequest,
+					Map.class);
+
+			// 응답에서 access_token 추출
+			Map tokenRes = (Map) tokenResponse.getBody().get("response");
+			accessToken = (String) tokenRes.get("access_token");
+
+			log.info("accessToken @@@@" + accessToken);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		// 2. imp_uid로 본인 인증 정보 조회
+		String certificationUrl = "https://api.iamport.kr/certifications/" + imp_uid;
+
+		HttpHeaders authHeaders = new HttpHeaders();
+		authHeaders.setBearerAuth(accessToken); // Bearer 토큰 설정
+
+		HttpEntity<String> authEntity = new HttpEntity<>(authHeaders);
+
+		ResponseEntity<Map> certificationResponse = restTemplate.exchange(certificationUrl, HttpMethod.GET, authEntity,
+				Map.class);
+
+		Map<String, Object> finalResult = new HashMap<>();
+		if (certificationResponse.getStatusCode().is2xxSuccessful()) {
+			Map<String, Object> responseBody = (Map<String, Object>) certificationResponse.getBody().get("response");
+
+			// 본인 인증 성공 시
+			finalResult.put("success", true);
+			finalResult.put("message", "본인 인증 정보 조회 성공");
+			finalResult.put("data", responseBody); // 인증 정보 데이터
+			log.info("@@@@ 인증 정보,birthday : " + responseBody);
+			log.info("@@@@ 인증 정보,birthday : " + responseBody.get("birthday"));
+			log.info("@@@@ 인증 정보,gender : " + responseBody.get("gender"));
+			log.info("@@@@ 인증 정보,name : " + responseBody.get("name"));
+
+		} else { // 본인 인증 실패 시 finalResult.put("success", false);
+			finalResult.put("message", "본인 인증 정보 조회 실패");
+			log.error("@@@@ 인증 정보 조회 실패: " + certificationResponse.getBody());
+		}
+
+		return finalResult;
 	}
 
 }

--- a/src/main/java/kr/or/ddit/account/join/service/impl/MemberJoinServiceImpl.java
+++ b/src/main/java/kr/or/ddit/account/join/service/impl/MemberJoinServiceImpl.java
@@ -129,7 +129,7 @@ public class MemberJoinServiceImpl implements MemberJoinService {
 		return memberJoinMapper.memberJoin(memberVO);
 	}
 
-	public static String formatPhoneNumber(String phoneNum) {
+	public String formatPhoneNumber(String phoneNum) {
 
 		if (phoneNum == null || phoneNum.length() != 11) {
 			return null;

--- a/src/main/java/kr/or/ddit/account/join/service/impl/MemberJoinServiceImpl.java
+++ b/src/main/java/kr/or/ddit/account/join/service/impl/MemberJoinServiceImpl.java
@@ -56,8 +56,6 @@ public class MemberJoinServiceImpl implements MemberJoinService {
 	@Override
 	public Map<String, Object> identityCheck(String imp_uid) {
 
-		log.info("imp_uid : @@@@@" + imp_uid);
-
 		if (imp_uid == null || imp_uid.isEmpty()) {
 			Map<String, Object> result = new HashMap<>();
 			result.put("success", false);
@@ -91,7 +89,6 @@ public class MemberJoinServiceImpl implements MemberJoinService {
 			Map tokenRes = (Map) tokenResponse.getBody().get("response");
 			accessToken = (String) tokenRes.get("access_token");
 
-			log.info("accessToken @@@@" + accessToken);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -115,14 +112,10 @@ public class MemberJoinServiceImpl implements MemberJoinService {
 			finalResult.put("success", true);
 			finalResult.put("message", "본인 인증 정보 조회 성공");
 			finalResult.put("data", responseBody); // 인증 정보 데이터
-			log.info("@@@@ 인증 정보,birthday : " + responseBody);
-			log.info("@@@@ 인증 정보,birthday : " + responseBody.get("birthday"));
-			log.info("@@@@ 인증 정보,gender : " + responseBody.get("gender"));
-			log.info("@@@@ 인증 정보,name : " + responseBody.get("name"));
 
 		} else { // 본인 인증 실패 시 finalResult.put("success", false);
 			finalResult.put("message", "본인 인증 정보 조회 실패");
-			log.error("@@@@ 인증 정보 조회 실패: " + certificationResponse.getBody());
+			log.error("인증 정보 조회 실패: " + certificationResponse.getBody());
 		}
 
 		return finalResult;
@@ -131,7 +124,6 @@ public class MemberJoinServiceImpl implements MemberJoinService {
 	@Override
 	public int memberJoin(MemberVO memberVO) {
 
-		log.info("회원가입 정보" + memberVO);
 		memberVO.setMemPassword(bCryptPasswordEncoder.encode(memberVO.getMemPassword()));
 		memberVO.setMemPhoneNumber(formatPhoneNumber(memberVO.getMemPhoneNumber()));
 		return memberJoinMapper.memberJoin(memberVO);

--- a/src/main/java/kr/or/ddit/account/join/web/MemberJoinController.java
+++ b/src/main/java/kr/or/ddit/account/join/web/MemberJoinController.java
@@ -1,9 +1,14 @@
 package kr.or.ddit.account.join.web;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.client.RestTemplate;
 
 import jakarta.servlet.http.HttpSession;
 import kr.or.ddit.account.join.service.MemberJoinService;
@@ -22,81 +28,150 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/join")
 @Slf4j
 public class MemberJoinController {
-	
+
 	@Autowired
-    private EmailService emailService;
-	
+	private EmailService emailService;
+
 	@Autowired
 	MemberJoinService memberJoinService;
-	
+
 	@GetMapping("/joinpage.do")
 	public String viewMemberJoinPage() {
-		
 		return "account/join";
 	}
-	
+
 	@PostMapping("/emailCheck.do")
 	@ResponseBody
 	public String emailCheck(@RequestBody Map<String, Object> inputEmail) {
-		
-		String email = (String)inputEmail.get("email");
+		String email = (String) inputEmail.get("email");
 		MemberVO member = memberJoinService.selectUserEmail(email);
-		
-		if(member != null) {
+
+		if (member != null) {
 			return "failed";
-		}else {
+		} else {
 			return "access";
 		}
 	}
-	
+
 	// 1. 인증 메일 전송
-    @PostMapping("/sendMail.do")
-    public ResponseEntity<?> sendEmail(@RequestBody Map<String, String> body, HttpSession session) {
-        log.info("메일전송 도착");
-    	String email = body.get("email");
-        String authCode = emailService.sendAuthCode(email);
+	@PostMapping("/sendMail.do")
+	public ResponseEntity<?> sendEmail(@RequestBody Map<String, String> body, HttpSession session) {
+		log.info("메일전송 도착");
+		String email = body.get("email");
+		String authCode = emailService.sendAuthCode(email);
 
-        session.setAttribute("authCode", authCode);
-        session.setAttribute("authCodeLimit", System.currentTimeMillis() + 3 * 60 * 1000); // 3분 제한
+		session.setAttribute("authCode", authCode);
+		session.setAttribute("authCodeLimit", System.currentTimeMillis() + 3 * 60 * 1000); // 3분 제한
 
-        return ResponseEntity.ok().body("sendOk");
-    }
+		return ResponseEntity.ok().body("sendOk");
+	}
 
-    // 2. 인증 코드 확인
-    @ResponseBody
-    @PostMapping("/verify.do")
-    public String verifyCode(@RequestBody Map<String, Object> body, HttpSession session) {
-        String inputCode = (String)body.get("code");
-        String savedCode = (String) session.getAttribute("authCode");
-        Long limitTime = (Long) session.getAttribute("authCodeLimit");
+	// 2. 인증 코드 확인
+	@ResponseBody
+	@PostMapping("/verify.do")
+	public String verifyCode(@RequestBody Map<String, Object> body, HttpSession session) {
+		String inputCode = (String) body.get("code");
+		String savedCode = (String) session.getAttribute("authCode");
+		Long limitTime = (Long) session.getAttribute("authCodeLimit");
+
+		if (savedCode == null || limitTime == null) {
+			return "인증을 다시 시도해주세요";
+		}
+
+		if (System.currentTimeMillis() > limitTime) {
+			return "인증 시간이 만료되었습니다.";
+		}
+
+		if (!savedCode.equals(inputCode)) {
+			return "인증 코드가 일치하지 않습니다.";
+		}
+
+		// 인증 성공 처리
+		session.removeAttribute("authCode");
+		session.removeAttribute("authCodeLimit");
+
+		return "success";
+	}
+
+	@ResponseBody
+	@PostMapping("/checkNickname.do")
+	public Map<String, Boolean> checkNickname(@RequestBody Map<String, String> request) {
+		String nickname = request.get("nickname");
+		boolean duplicate = memberJoinService.isNicknameExists(nickname);
+
+		Map<String, Boolean> response = new HashMap<String, Boolean>();
+		response.put("duplicate", duplicate);
+		return response;
+	}
+
+	@PostMapping("/identityCheck.do")
+	@ResponseBody
+	public Map<String, Object> identityCheck() {
+		/*
+		 * @RequestBody Map<String, Object> requestBody
+		 * String imp_uid = (String) requestBody.get("imp_uid");
+		 * log.info("@@@@ imp_uid: " + imp_uid);
+		 * 
+		 * if (imp_uid == null || imp_uid.isEmpty()) { Map<String, Object> result = new
+		 * HashMap<>(); result.put("success", false); result.put("message",
+		 * "imp_uid가 누락되었습니다."); return result; }
+		 */
+
+		RestTemplate restTemplate = new RestTemplate();
+
+        // 1. 인증 토큰 발급
+        String tokenUrl = "https://api.iamport.kr/users/getToken";
+
+        HttpHeaders tokenHeaders = new HttpHeaders();
+        tokenHeaders.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+        Map<String, String> tokenBody = new HashMap<>();
+        tokenBody.put("imp_key", "1483263617088817"); // REST API 키
+        tokenBody.put("imp_secret", "ZcbZ47ZHF536xGHAj4FVCNDTp2OZYhy6zW6nNwVNGSwq4Z7tATU5CUxGGRZtWfRgBE57PIFkL7kMovVs"); // REST API Secret
+
+        HttpEntity<Map<String, String>> tokenRequest = new HttpEntity<>(tokenBody, tokenHeaders);
+
+        ResponseEntity<Map> tokenResponse = restTemplate.exchange(
+                tokenUrl,
+                HttpMethod.POST,
+                tokenRequest,
+                Map.class
+        );
+
+        // 응답에서 access_token 추출
+        Map tokenRes = (Map) tokenResponse.getBody().get("response");
+        String accessToken = (String) tokenRes.get("access_token");
         
-        if (savedCode == null || limitTime == null) {
-            return "인증을 다시 시도해주세요";
-        }
+        
+        log.info("accessToken @@@@" + accessToken);
 
-        if (System.currentTimeMillis() > limitTime) {
-            return "인증 시간이 만료되었습니다.";
-        }
+		// 2. imp_uid로 본인 인증 정보 조회
+		/*
+		 * String certificationUrl = "https://api.iamport.kr/certifications/" + imp_uid;
+		 * 
+		 * HttpHeaders authHeaders = new HttpHeaders();
+		 * authHeaders.setBearerAuth(accessToken); // Bearer 토큰 설정
+		 * 
+		 * HttpEntity<String> authEntity = new HttpEntity<>(authHeaders);
+		 * 
+		 * ResponseEntity<Map> certificationResponse =
+		 * restTemplate.exchange(certificationUrl, HttpMethod.GET, authEntity,
+		 * Map.class);
+		 * 
+		 * Map<String, Object> finalResult = new HashMap<>(); if
+		 * (certificationResponse.getStatusCode().is2xxSuccessful()) { Map<String,
+		 * Object> responseBody = (Map<String, Object>)
+		 * certificationResponse.getBody().get("response");
+		 * 
+		 * // 본인 인증 성공 시 finalResult.put("success", true); finalResult.put("message",
+		 * "본인 인증 정보 조회 성공"); finalResult.put("data", responseBody); // 인증 정보 데이터
+		 * log.info("@@@@ 인증 정보: " + responseBody);
+		 * 
+		 * } else { // 본인 인증 실패 시 finalResult.put("success", false);
+		 * finalResult.put("message", "본인 인증 정보 조회 실패"); log.error("@@@@ 인증 정보 조회 실패: "
+		 * + certificationResponse.getBody()); }
+		 */
 
-        if (!savedCode.equals(inputCode)) {
-            return "인증 코드가 일치하지 않습니다.";
-        }
-
-        // 인증 성공 처리
-        session.removeAttribute("authCode");
-        session.removeAttribute("authCodeLimit");
-
-        return "success";
-    }
-    
-    @ResponseBody
-    @PostMapping("/checkNickname.do")
-    public Map<String, Boolean> checkNickname(@RequestBody Map<String, String> request) {
-        String nickname = request.get("nickname");
-        boolean duplicate = memberJoinService.isNicknameExists(nickname);
-
-        Map<String, Boolean> response = new HashMap<String, Boolean>();
-        response.put("duplicate", duplicate);
-        return response;
-    }
+		return null;
+	}
 }

--- a/src/main/java/kr/or/ddit/account/join/web/MemberJoinController.java
+++ b/src/main/java/kr/or/ddit/account/join/web/MemberJoinController.java
@@ -57,7 +57,6 @@ public class MemberJoinController {
 	// 1. 인증 메일 전송
 	@PostMapping("/sendMail.do")
 	public ResponseEntity<?> sendEmail(@RequestBody Map<String, String> body, HttpSession session) {
-		log.info("메일전송 도착");
 		String email = body.get("email");
 		String authCode = emailService.sendAuthCode(email);
 

--- a/src/main/java/kr/or/ddit/account/join/web/MemberJoinController.java
+++ b/src/main/java/kr/or/ddit/account/join/web/MemberJoinController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,7 +35,7 @@ public class MemberJoinController {
 
 	@Autowired
 	MemberJoinService memberJoinService;
-
+	
 	@GetMapping("/joinpage.do")
 	public String viewMemberJoinPage() {
 		return "account/join";
@@ -113,10 +114,15 @@ public class MemberJoinController {
 	}
 
 	@PostMapping("/memberJoin.do")
-	public String memberJoin(MemberVO memberVO) {
+	public String memberJoin(MemberVO memberVO, Model model) {
 		
-		memberJoinService.memberJoin(memberVO);
+		int result = memberJoinService.memberJoin(memberVO);
+		if (result > 0) {
+			model.addAttribute("registMessage", "가입이 완료되었습니다.");
+		} else {
+			model.addAttribute("registMessage", "가입이 실패하였습니다.");
+		}
 		
-		return "";
+		return "account/login";
 	}
 }

--- a/src/main/java/kr/or/ddit/account/join/web/MemberJoinController.java
+++ b/src/main/java/kr/or/ddit/account/join/web/MemberJoinController.java
@@ -106,72 +106,17 @@ public class MemberJoinController {
 
 	@PostMapping("/identityCheck.do")
 	@ResponseBody
-	public Map<String, Object> identityCheck() {
-		/*
-		 * @RequestBody Map<String, Object> requestBody
-		 * String imp_uid = (String) requestBody.get("imp_uid");
-		 * log.info("@@@@ imp_uid: " + imp_uid);
-		 * 
-		 * if (imp_uid == null || imp_uid.isEmpty()) { Map<String, Object> result = new
-		 * HashMap<>(); result.put("success", false); result.put("message",
-		 * "imp_uid가 누락되었습니다."); return result; }
-		 */
+	public Map<String, Object> identityCheck(@RequestBody Map<String, Object> requestBody) {
+		String imp_uid = (String) requestBody.get("imp_uid");
+		return memberJoinService.identityCheck(imp_uid);
 
-		RestTemplate restTemplate = new RestTemplate();
+	}
 
-        // 1. 인증 토큰 발급
-        String tokenUrl = "https://api.iamport.kr/users/getToken";
-
-        HttpHeaders tokenHeaders = new HttpHeaders();
-        tokenHeaders.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
-
-        Map<String, String> tokenBody = new HashMap<>();
-        tokenBody.put("imp_key", "1483263617088817"); // REST API 키
-        tokenBody.put("imp_secret", "ZcbZ47ZHF536xGHAj4FVCNDTp2OZYhy6zW6nNwVNGSwq4Z7tATU5CUxGGRZtWfRgBE57PIFkL7kMovVs"); // REST API Secret
-
-        HttpEntity<Map<String, String>> tokenRequest = new HttpEntity<>(tokenBody, tokenHeaders);
-
-        ResponseEntity<Map> tokenResponse = restTemplate.exchange(
-                tokenUrl,
-                HttpMethod.POST,
-                tokenRequest,
-                Map.class
-        );
-
-        // 응답에서 access_token 추출
-        Map tokenRes = (Map) tokenResponse.getBody().get("response");
-        String accessToken = (String) tokenRes.get("access_token");
-        
-        
-        log.info("accessToken @@@@" + accessToken);
-
-		// 2. imp_uid로 본인 인증 정보 조회
-		/*
-		 * String certificationUrl = "https://api.iamport.kr/certifications/" + imp_uid;
-		 * 
-		 * HttpHeaders authHeaders = new HttpHeaders();
-		 * authHeaders.setBearerAuth(accessToken); // Bearer 토큰 설정
-		 * 
-		 * HttpEntity<String> authEntity = new HttpEntity<>(authHeaders);
-		 * 
-		 * ResponseEntity<Map> certificationResponse =
-		 * restTemplate.exchange(certificationUrl, HttpMethod.GET, authEntity,
-		 * Map.class);
-		 * 
-		 * Map<String, Object> finalResult = new HashMap<>(); if
-		 * (certificationResponse.getStatusCode().is2xxSuccessful()) { Map<String,
-		 * Object> responseBody = (Map<String, Object>)
-		 * certificationResponse.getBody().get("response");
-		 * 
-		 * // 본인 인증 성공 시 finalResult.put("success", true); finalResult.put("message",
-		 * "본인 인증 정보 조회 성공"); finalResult.put("data", responseBody); // 인증 정보 데이터
-		 * log.info("@@@@ 인증 정보: " + responseBody);
-		 * 
-		 * } else { // 본인 인증 실패 시 finalResult.put("success", false);
-		 * finalResult.put("message", "본인 인증 정보 조회 실패"); log.error("@@@@ 인증 정보 조회 실패: "
-		 * + certificationResponse.getBody()); }
-		 */
-
-		return null;
+	@PostMapping("/memberJoin.do")
+	public String memberJoin(MemberVO memberVO) {
+		
+		memberJoinService.memberJoin(memberVO);
+		
+		return "";
 	}
 }

--- a/src/main/java/kr/or/ddit/mpg/mif/inq/service/MyInquiryService.java
+++ b/src/main/java/kr/or/ddit/mpg/mif/inq/service/MyInquiryService.java
@@ -25,4 +25,6 @@ public interface MyInquiryService {
 	void insertVerification(String memId, String vCategory, MultipartFile authFile);
 	
 	MemberVO getProfileFile(MemberVO member);
+
+	int updateMemberPhone(String imp_uid, String memId);
 }

--- a/src/main/java/kr/or/ddit/mpg/mif/inq/service/impl/MyInquiryMapper.java
+++ b/src/main/java/kr/or/ddit/mpg/mif/inq/service/impl/MyInquiryMapper.java
@@ -32,4 +32,6 @@ public interface MyInquiryMapper {
 
 	MemberVO getProfileFile(int memId);
 
+	int updateMemberPhone(MemberVO memberVO);
+
 }

--- a/src/main/java/kr/or/ddit/mpg/mif/inq/service/impl/MyInquiryServiceImpl.java
+++ b/src/main/java/kr/or/ddit/mpg/mif/inq/service/impl/MyInquiryServiceImpl.java
@@ -1,16 +1,28 @@
 package kr.or.ddit.mpg.mif.inq.service.impl;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.google.gson.Gson;
+
+import kr.or.ddit.account.join.service.MemberJoinService;
 import kr.or.ddit.com.ComCodeVO;
 import kr.or.ddit.exception.CustomException;
 import kr.or.ddit.exception.ErrorCode;
@@ -33,7 +45,15 @@ public class MyInquiryServiceImpl implements MyInquiryService {
 
 	@Autowired
 	FileService fileService;
-
+	
+	@Autowired
+	MemberJoinService memberJoinService;
+	
+	@Value("${imp.identity.key}")
+	private String IMP_IDENTITY_KEY;
+	@Value("${imp.identity.secret}")
+	private String IMP_IDENTITY_SECRET;
+	
 	/**
 	 * 마이페이지 진입 전 멤버의 정보를 확인합니다.
 	 * 
@@ -48,19 +68,19 @@ public class MyInquiryServiceImpl implements MyInquiryService {
 		if (member == null) {
 			throw new CustomException(ErrorCode.USER_NOT_FOUND);
 		}
-		
+
 		member = getProfileFile(member);
 
 		List<ComCodeVO> interetsKeywordList = this.myInquiryMapper.selectInteretsKeywordList();
 
 		return Map.of("member", member, "interetsKeywordList", interetsKeywordList);
 	}
-	
+
 	/**
 	 * 멤버의 비밀번호를 확인합니다.
 	 * 
 	 * @param memIdStr 멤버id
-	 * @param password   확인용 비밀번호
+	 * @param password 확인용 비밀번호
 	 */
 	@Override
 	public void checkPassword(String memIdStr, String password) {
@@ -76,8 +96,8 @@ public class MyInquiryServiceImpl implements MyInquiryService {
 	/**
 	 * form데이터로 받은 변경 내용을 업데이트합니다.
 	 * 
-	 * @param memIdStr  멤버id
-	 * @param member 변경 내용
+	 * @param memIdStr 멤버id
+	 * @param member   변경 내용
 	 */
 	@Override
 	public void updateMyInquiryView(String memIdStr, MemberVO member) {
@@ -124,7 +144,7 @@ public class MyInquiryServiceImpl implements MyInquiryService {
 		if (result == 0) {
 			throw new CustomException(ErrorCode.USER_UPDATE_FAILED);
 		}
-		
+
 		return fileService.getFileDetail(fileGroupId, 1);
 	}
 
@@ -158,12 +178,9 @@ public class MyInquiryServiceImpl implements MyInquiryService {
 		}
 		Long fileGroupId = fileService.createFileGroup();
 
-		VerificationVO verification = VerificationVO.builder()
-												.memId(memId)
-												.fileGroupId(fileGroupId)
-												.veriCategory(vCategory)
-												.build();
-		
+		VerificationVO verification = VerificationVO.builder().memId(memId).fileGroupId(fileGroupId)
+				.veriCategory(vCategory).build();
+
 		List<MultipartFile> files = new ArrayList<MultipartFile>();
 		files.add(authFile);
 
@@ -178,7 +195,7 @@ public class MyInquiryServiceImpl implements MyInquiryService {
 			throw new CustomException(ErrorCode.USER_UPDATE_FAILED);
 		}
 	}
-	
+
 	/**
 	 * String타입의 멤버 Id를 int 타입으로 변환합니다.
 	 * 
@@ -189,7 +206,7 @@ public class MyInquiryServiceImpl implements MyInquiryService {
 		if (memIdStr == null || memIdStr.equals("anonymousUser")) {
 			throw new CustomException(ErrorCode.INVALID_AUTHORIZE);
 		}
-		
+
 		int memId;
 		try {
 			memId = Integer.parseInt(memIdStr);
@@ -199,38 +216,107 @@ public class MyInquiryServiceImpl implements MyInquiryService {
 
 		return memId;
 	}
-	
+
 	@Override
 	public MemberVO getProfileFile(MemberVO member) {
-	    int memId = member.getMemId();
-	    
-	    MemberVO profile = this.myInquiryMapper.getProfileFile(memId);
-	    
-	    if (profile == null) {
-	        return member;
-	    }
-	    
-	    member.setProfileFilePath(getFilePathFromId(profile.getFileProfile()));
-	    member.setBadgeFilePath(getFilePathFromId(profile.getFileBadge()));
-	    member.setSubFilePath(getFilePathFromId(profile.getFileSub()));
-	    
-	    member.setMemId(memId);
-	    
-	    return member;
+		int memId = member.getMemId();
+
+		MemberVO profile = this.myInquiryMapper.getProfileFile(memId);
+
+		if (profile == null) {
+			return member;
+		}
+
+		member.setProfileFilePath(getFilePathFromId(profile.getFileProfile()));
+		member.setBadgeFilePath(getFilePathFromId(profile.getFileBadge()));
+		member.setSubFilePath(getFilePathFromId(profile.getFileSub()));
+
+		member.setMemId(memId);
+
+		return member;
 	}
-	
+
 	private String getFilePathFromId(Long fileId) {
-	    // 파일 ID 자체가 null이면 null 반환
-	    if (fileId == null) {
-	        return null;
-	    }
-	    
-	    FileDetailVO fileDetail = fileService.getFileDetail(fileId, 1);
-	    
-	    if (fileDetail == null) {
-	    	return null;
-	    }
-	    
-	    return this.fileService.getSavePath(fileDetail);
+		// 파일 ID 자체가 null이면 null 반환
+		if (fileId == null) {
+			return null;
+		}
+
+		FileDetailVO fileDetail = fileService.getFileDetail(fileId, 1);
+
+		if (fileDetail == null) {
+			return null;
+		}
+
+		return this.fileService.getSavePath(fileDetail);
+	}
+
+	@Override
+	public int updateMemberPhone(String imp_uid, String memId) {
+
+		if (imp_uid == null || imp_uid.isEmpty()) {
+			return 0;
+		}
+
+		RestTemplate restTemplate = new RestTemplate();
+
+		String tokenUrl = "https://api.iamport.kr/users/getToken";
+
+		HttpHeaders tokenHeaders = new HttpHeaders();
+		tokenHeaders.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+		Map<String, String> tokenBody = new HashMap<>();
+		tokenBody.put("imp_key", IMP_IDENTITY_KEY); // REST API 키
+		tokenBody.put("imp_secret", IMP_IDENTITY_SECRET);
+
+		Gson gson = new Gson();
+		String jsonBody = gson.toJson(tokenBody);
+
+		String accessToken = "";
+		try {
+			HttpEntity<String> tokenRequest = new HttpEntity<>(jsonBody, tokenHeaders);
+
+			ResponseEntity<Map> tokenResponse = restTemplate.exchange(tokenUrl, HttpMethod.POST, tokenRequest,
+					Map.class);
+
+			Map tokenRes = (Map) tokenResponse.getBody().get("response");
+			accessToken = (String) tokenRes.get("access_token");
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		String certificationUrl = "https://api.iamport.kr/certifications/" + imp_uid;
+
+		HttpHeaders authHeaders = new HttpHeaders();
+		authHeaders.setBearerAuth(accessToken); // Bearer 토큰 설정
+
+		HttpEntity<String> authEntity = new HttpEntity<>(authHeaders);
+
+		ResponseEntity<Map> certificationResponse = restTemplate.exchange(certificationUrl, HttpMethod.GET, authEntity,
+				Map.class);
+
+		Map<String, Object> finalResult = new HashMap<>();
+		if (certificationResponse.getStatusCode().is2xxSuccessful()) {
+			Map<String, Object> responseBody = (Map<String, Object>) certificationResponse.getBody().get("response");
+			
+			log.info("전체 데이터"+responseBody);
+			log.info("변경된 폰넘버"+responseBody.get("phone"));
+			
+			MemberVO member = this.myInquiryMapper.selectMyInquiryView(parseMemId(memId));
+			
+			if(member.getMemName().equals(responseBody.get("name"))) {
+				member.setMemId(parseMemId(memId));
+				member.setMemPhoneNumber(memberJoinService.formatPhoneNumber((String) responseBody.get("phone")));
+				return myInquiryMapper.updateMemberPhone(member);
+			} else {
+				log.error("사용자 불일치");
+			}
+			
+		} else {
+			log.error("인증 정보 조회 실패: " + certificationResponse.getBody());
+		}
+
+		return 0;
 	}
 }

--- a/src/main/java/kr/or/ddit/mpg/mif/inq/web/MyInquiryController.java
+++ b/src/main/java/kr/or/ddit/mpg/mif/inq/web/MyInquiryController.java
@@ -171,4 +171,19 @@ public class MyInquiryController {
 			return new ResponseEntity<>(response, errorCode.getStatus());
 		}
 	}
+	
+	@PostMapping("/mif/inq/updateMemberPhone.do")
+	@ResponseBody
+	public String updateMemberPhone(@AuthenticationPrincipal String memId, @RequestBody Map<String, Object> requestBody, Model model) {
+		String imp_uid = (String) requestBody.get("imp_uid");
+		int res = myInquiryService.updateMemberPhone(imp_uid, memId);
+		
+		if(res > 0) {
+			return "번호 변경이 완료되었습니다.";
+		} else {
+			return "번호 변경이 실패하였습니다.";
+		}
+		
+		 
+	}
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -27,3 +27,7 @@ gemini.api.url=${DEV.AI.GEMINI.URL}
 #메일 설정
 spring.mail.username=${DEV.MAIL.USERNAME}
 spring.mail.password=${DEV.MAIL.PASSWORD}
+
+# 본인인증
+imp.identity.key=${DEV.JOIN.IMP_API_KEY}
+imp.identity.secret=${DEV.JOIN.IMP_SECRET}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -28,6 +28,10 @@ gemini.api.url=${PROD.AI.GEMINI.URL}
 spring.mail.username=${PROD.MAIL.USERNAME}
 spring.mail.password=${PROD.MAIL.PASSWORD}
 
+# 본인인증
+imp.identity.key=${DEV.JOIN.IMP_API_KEY}
+imp.identity.secret=${DEV.JOIN.IMP_SECRET}
+
 # 운영환경 로깅 설정 (ERROR, WARN 레벨만)
 logging.level.kr.or.ddit=DEBUG
 logging.level.org.springframework=WARN

--- a/src/main/resources/mybatis/mapper/memberJoin-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/memberJoin-Mapper.xml
@@ -19,4 +19,45 @@
 		WHERE MEM_NICKNAME = #{nickName}
 	</select>
 
+	<insert id="memberJoin"	parameterType="kr.or.ddit.main.service.MemberVO">
+		<selectKey keyProperty="memId" resultType="int"
+			order="BEFORE">
+			SELECT NVL(MAX(MEM_ID),0)+1 FROM MEMBER
+		</selectKey>
+		INSERT INTO MEMBER (
+		    MEM_ID
+		    , MEM_EMAIL
+		    , MEM_PASSWORD
+		    , MEM_NICKNAME
+		    , MEM_PHONE_NUMBER
+		    , MEM_NAME
+		    , MEM_GEN
+		    , MEM_BIRTH
+		    , MEM_ALARM
+		    , MEM_STUDENT
+		    , MEM_ROLE
+		    , MEM_POINT
+		    , CREATED_AT
+		    , PW_UPDATED_AT
+		    , DEL_YN
+		    , LOGIN_TYPE
+		) VALUES (
+		    #{memId}
+		  , #{memEmail}
+		  , #{memPassword}
+		  , #{memNickname}
+		  , #{memPhoneNumber}
+		  , #{memName}
+		  , #{memGen}
+		  , #{memBirth}
+		  , #{memAlarm}
+		  , 'N'
+		  , 'R01001'
+		  , 0
+		  , SYSDATE
+		  , SYSDATE
+		  , 'N'
+		  , 'G33001'
+		)
+	</insert>
 </mapper>

--- a/src/main/resources/mybatis/mapper/myInquiry-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/myInquiry-Mapper.xml
@@ -199,4 +199,12 @@
 		WHERE
 		    MEM_ID = #{memId}
 	</select>
+	
+	<update id="updateMemberPhone" parameterType="kr.or.ddit.main.service.MemberVO">
+		UPDATE MEMBER
+		SET
+		    MEM_PHONE_NUMBER = #{memPhoneNumber}
+		WHERE
+		    MEM_ID = #{memId}
+	</update>
 </mapper>

--- a/src/main/resources/static/css/common/userCommon.css
+++ b/src/main/resources/static/css/common/userCommon.css
@@ -10,7 +10,8 @@
 	font-style: normal;
 }
 
-html, body {
+html,
+body {
 	margin: 0;
 	padding: 0;
 	font-family: 'Noto Sans KR', sans-serif;
@@ -29,27 +30,27 @@ html, body {
 	font-size: 18px;
 	padding: 15px 0;
 	margin: 0;
-    flex: 1;
-    text-align: center;
-    position: relative;
-    color: black;
-    z-index: 1;
-    text-decoration: none;
-    font-weight: 500;
+	flex: 1;
+	text-align: center;
+	position: relative;
+	color: black;
+	z-index: 1;
+	text-decoration: none;
+	font-weight: 500;
 }
 
 .public-wrapper-main {
 	position: relative;
-    margin: 20px auto 0 auto;
-    background-color: #fff;
-    border-radius: 16px;
-    padding: 40px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+	margin: 20px auto 0 auto;
+	background-color: #fff;
+	border-radius: 16px;
+	padding: 40px;
+	box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
 }
 
 /* ==========================================================================
    플로팅 바
-   ========================================================================== */  
+   ========================================================================== */
 .floating-bar {
 	position: fixed;
 	top: 30%;
@@ -81,6 +82,7 @@ html, body {
 		opacity: 0;
 		transform: translateY(-20px);
 	}
+
 	100% {
 		opacity: 1;
 		transform: translateY(0);
@@ -141,7 +143,7 @@ html, body {
 }
 
 .channel-sub-section-item {
-	font-size : 18px;
+	font-size: 18px;
 	font-weight: 600;
 	color: #848484;
 	width: 150px;
@@ -149,7 +151,7 @@ html, body {
 }
 
 .channel-sub-section-itemIn {
-	font-size : 18px;
+	font-size: 18px;
 	font-weight: 600;
 	width: 150px;
 	text-align: center;
@@ -223,6 +225,8 @@ html, body {
 	position: relative;
 	z-index: 1000;
 	padding: 0 100px;
+	border-bottom: 2px solid;
+	border-color: rgba(217, 217, 217, 0.5);
 }
 
 .header__brand a {
@@ -250,7 +254,8 @@ html, body {
 	position: relative;
 }
 
-.main-nav__item a, .main-nav__link {
+.main-nav__item a,
+.main-nav__link {
 	text-decoration: none;
 	color: #626262;
 	font-size: 18px;
@@ -260,7 +265,8 @@ html, body {
 	transition: color 0.3s ease;
 }
 
-.main-nav__item a:hover, .main-nav__link:hover {
+.main-nav__item a:hover,
+.main-nav__link:hover {
 	color: #848EFB;
 }
 
@@ -491,8 +497,10 @@ html, body {
 	color: #fff;
 	text-decoration: underline;
 }
-   
-.header__mobile-menu-trigger, .mobile-nav-panel, .overlay {
+
+.header__mobile-menu-trigger,
+.mobile-nav-panel,
+.overlay {
 	display: none;
 }
 
@@ -615,10 +623,10 @@ html, body {
 	margin-bottom: 12px;
 	background-color: #fff;
 }
-	
+
 .search-filter__input-wrapper {
 	display: flex;
-    width: 100%;
+	width: 100%;
 }
 
 .search-filter__select-wrapper {
@@ -732,7 +740,7 @@ html, body {
 	transition: padding 0.3s ease-out;
 }
 
-.search-filter__accordion-panel.is-open .search-filter__accordion-content{
+.search-filter__accordion-panel.is-open .search-filter__accordion-content {
 	border-top: 1px solid #e5e7eb;
 	padding: 24px;
 }
@@ -846,20 +854,21 @@ html, body {
    ========================================================================== */
 .content-list {
 	display: flex;
-    flex-direction: column;
-    gap: 16px;
-    margin-bottom: 40px;
+	flex-direction: column;
+	gap: 16px;
+	margin-bottom: 40px;
 }
 
 .content-list__total-count {
-    font-size: 0.9rem;
-    color: #6b7280;
-    margin-bottom: 15px;
-    text-align: right;
+	font-size: 0.9rem;
+	color: #6b7280;
+	margin-bottom: 15px;
+	text-align: right;
 }
 
 .content-list__header {
-	display: flex; /* 내부 정렬을 위해 flex는 유지 */
+	display: flex;
+	/* 내부 정렬을 위해 flex는 유지 */
 	align-items: center;
 	background-color: #f3f4f6;
 	font-weight: 600;
@@ -878,7 +887,7 @@ html, body {
 
 /* 리스트 아이템 */
 .content-list__item {
-    padding: 20px 24px;
+	padding: 20px 24px;
 	display: flex;
 	align-items: center;
 	border: 1px solid #e5e7eb;
@@ -888,7 +897,7 @@ html, body {
 
 .content-list__item:hover {
 	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-    border-color: #d1d5db;
+	border-color: #d1d5db;
 	cursor: pointer;
 }
 
@@ -916,7 +925,8 @@ html, body {
 
 .content-list__meta-item {
 	display: flex;
-	flex: 1; /* 그룹 내에서 균등 분배 */
+	flex: 1;
+	/* 그룹 내에서 균등 분배 */
 	gap: 8px;
 	align-items: center;
 }
@@ -962,41 +972,45 @@ html, body {
    아코디언 리스트
    ========================================================================== */
 .accordion-list__header {
-    display: flex;
-    padding: 12px 24px;
-    background-color: #f3f4f6;
-    font-weight: 600;
-    color: #4b5563;
-    border-radius: 8px;
+	display: flex;
+	padding: 12px 24px;
+	background-color: #f3f4f6;
+	font-weight: 600;
+	color: #4b5563;
+	border-radius: 8px;
 }
 
 .accordion-list__item {
-    border: 1px solid #e5e7eb;
-    border-radius: 10px;
-    background-color: #fff;
-    overflow: hidden; /* 애니메이션을 위해 추가 */
-    transition: box-shadow 0.2s ease;
+	border: 1px solid #e5e7eb;
+	border-radius: 10px;
+	background-color: #fff;
+	overflow: hidden;
+	/* 애니메이션을 위해 추가 */
+	transition: box-shadow 0.2s ease;
 }
+
 .accordion-list__item:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-    border-color: #d1d5db;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+	border-color: #d1d5db;
 }
 
 .accordion-list__item-header {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    transition: background-color 0.2s ease;
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+	transition: background-color 0.2s ease;
 }
+
 .accordion-list__item-header:hover {
-    background-color: #f9fafb;
+	background-color: #f9fafb;
 }
+
 .accordion-list__item-header.is-active {
-    border-bottom: 1px solid #e5e7eb;
+	border-bottom: 1px solid #e5e7eb;
 }
 
 .accordion-list__toggle-icon {
-   	display: flex;
+	display: flex;
 	align-items: center;
 	justify-content: center;
 	width: 24px;
@@ -1005,26 +1019,28 @@ html, body {
 	transition: transform 0.2s ease;
 	color: #656d76;
 }
+
 .accordion-list__toggle-icon.is-active {
-    transform: rotate(180deg);
+	transform: rotate(180deg);
 }
 
 .accordion-list__item-content {
 	padding: 0 20px;
-    display: grid;
-    grid-template-rows: 0fr;
-    transition: grid-template-rows 0.3s ease, padding 0.3s ease-in-out;;
-    overflow: hidden;
+	display: grid;
+	grid-template-rows: 0fr;
+	transition: grid-template-rows 0.3s ease, padding 0.3s ease-in-out;
+	;
+	overflow: hidden;
 }
 
 .accordion-list__item-content.is-active {
-    padding: 20px;
-    grid-template-rows: 1fr;
+	padding: 20px;
+	grid-template-rows: 1fr;
 }
 
 .accordion-list__content-body {
-    min-height: 0;
-    overflow: hidden;
+	min-height: 0;
+	overflow: hidden;
 }
 
 .accordion-list__col {
@@ -1128,31 +1144,31 @@ html, body {
    게시글 상세 - 공통 스타일 (userCommon.css에 추가)
    ========================================================================== */
 .detail__header-wrapper {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    padding-bottom: 40px;
-    gap: 20px;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding-bottom: 40px;
+	gap: 20px;
 }
 
 /* 상세 헤더 */
 .detail__header {
 	display: flex;
-    align-items: center;
-    gap: 12px;
+	align-items: center;
+	gap: 12px;
 }
 
 .detail__badge {
-    background: #e8f4f8;
-    color: #2196f3;
-    font-weight: bold;
-    font-size: 12px;
-    padding: 6px 15px;
-    border-radius: 15px;
-    min-width: 40px;
-    text-align: center;
-    flex-shrink: 0;
-    margin-top: 2px;
+	background: #e8f4f8;
+	color: #2196f3;
+	font-weight: bold;
+	font-size: 12px;
+	padding: 6px 15px;
+	border-radius: 15px;
+	min-width: 40px;
+	text-align: center;
+	flex-shrink: 0;
+	margin-top: 2px;
 }
 
 .detail__title {
@@ -1167,8 +1183,8 @@ html, body {
 
 /* 상세 메타 정보 */
 .detail__meta {
-    font-size: 13px;
-    color: #888;
+	font-size: 13px;
+	color: #888;
 }
 
 .detail__meta-item {
@@ -1391,20 +1407,25 @@ html, body {
    반응형 스타일
    ========================================================================== */
 @media (max-width: 1024px) {
+
 	/* 탑바 */
 	.main-nav__item--priority-low {
 		display: none;
 	}
+
 	.main-nav {
 		gap: 30px;
 	}
-	.main-nav__item a, .main-nav__link {
+
+	.main-nav__item a,
+	.main-nav__link {
 		font-size: 16px;
 	}
+
 	.header {
 		padding: 0 3%;
 	}
-	
+
 	/* 서브메뉴 */
 	.mega-menu__container {
 		max-width: 1200px;
@@ -1414,27 +1435,32 @@ html, body {
 		grid-template-columns: 1fr 1fr;
 		gap: 20px;
 	}
+
 	.mega-menu__row {
 		display: contents;
 	}
+
 	.mega-menu__category {
 		max-width: none;
 		min-width: auto;
 	}
-	
+
 	/* 푸터 */
 	.footer__info {
 		flex-basis: 40%;
 	}
+
 	.footer__navigation {
 		flex-basis: 50%;
 	}
+
 	.footer__nav-group {
 		flex-basis: calc(50% - 20px);
 	}
 }
 
-@media ( max-width : 768px) {
+@media (max-width : 768px) {
+
 	/* 공통 레이아웃 */
 	.public-wrapper-main {
 		padding: 20px;
@@ -1442,30 +1468,36 @@ html, body {
 
 	/* 소메뉴 탭 */
 	.tab-container {
-		font-size: 16px; /* 모바일에서 폰트 크기 축소 */
+		font-size: 16px;
+		/* 모바일에서 폰트 크기 축소 */
 	}
+
 	.tab {
 		padding: 12px 5px;
 	}
-	
+
 	/* 탑바 */
 	.header {
 		padding: 0 15px;
 	}
-	.header__nav-container--desktop, .header__user-actions--desktop {
+
+	.header__nav-container--desktop,
+	.header__user-actions--desktop {
 		display: none;
 	}
+
 	.header__mobile-menu-trigger {
 		display: block;
 		background: none;
 		border: none;
 		cursor: pointer;
 	}
+
 	.header__mobile-menu-trigger img {
 		width: 28px;
 		height: 28px;
 	}
-	
+
 	/* 모바일 메뉴 */
 	.overlay {
 		display: block;
@@ -1480,10 +1512,12 @@ html, body {
 		visibility: hidden;
 		transition: opacity 0.3s ease, visibility 0.3s ease;
 	}
+
 	.overlay.is-active {
 		opacity: 1;
 		visibility: visible;
 	}
+
 	.mobile-nav-panel {
 		display: flex;
 		flex-direction: column;
@@ -1500,25 +1534,31 @@ html, body {
 		transform: translateX(100%);
 		transition: transform 0.3s ease-in-out;
 	}
+
 	.mobile-nav-panel.is-active {
 		transform: translateX(0);
 	}
+
 	.mobile-nav-panel__header {
 		text-align: right;
 		margin-bottom: 20px;
 	}
+
 	.mobile-nav-panel__close {
 		background: none;
 		border: none;
 		font-size: 24px;
 		cursor: pointer;
 	}
+
 	.mobile-nav-panel__close {
 		width: 32px;
 		height: 32px;
 		position: relative;
 	}
-	.mobile-nav-panel__close::before, .mobile-nav-panel__close::after {
+
+	.mobile-nav-panel__close::before,
+	.mobile-nav-panel__close::after {
 		content: '';
 		position: absolute;
 		top: 50%;
@@ -1528,9 +1568,11 @@ html, body {
 		background-color: #666;
 		transform: translate(-50%, -50%) rotate(45deg);
 	}
+
 	.mobile-nav-panel__close::after {
 		transform: translate(-50%, -50%) rotate(-45deg);
 	}
+
 	.mobile-nav-panel__menu {
 		list-style: none;
 		padding: 0;
@@ -1538,9 +1580,11 @@ html, body {
 		flex: 1;
 		overflow-y: auto;
 	}
+
 	.mobile-nav-panel__menu li {
 		border-bottom: 1px solid #eee;
 	}
+
 	.mobile-nav-panel__menu a {
 		font-weight: 500;
 		display: block;
@@ -1549,6 +1593,7 @@ html, body {
 		color: #333;
 		font-size: 18px;
 	}
+
 	.mobile-nav-panel__user-actions {
 		margin-top: auto;
 		padding-top: 20px;
@@ -1556,35 +1601,37 @@ html, body {
 		display: flex;
 		justify-content: space-around;
 	}
+
 	.mobile-nav-panel__user-actions a {
 		text-decoration: none;
 		color: #555;
 		font-size: 16px;
 		padding: 10px;
 	}
-	
+
 	/* 서브 메뉴 */
 	.mega-menu {
 		display: none;
 	}
-	
+
 	/* 대, 중메뉴 */
 	.channel-sub-sections {
 		gap: 0;
 	}
-	
-	
+
+
 	/* 플로팅바 */
 	.floating-bar {
 		right: 10px;
 		gap: 10px;
 	}
+
 	.floating-bar__button {
 		width: 50px;
 		height: 50px;
 		padding: 8px;
 	}
-	
+
 	/* 푸터 */
 	.footer {
 		padding-top: 40px;
@@ -1601,12 +1648,12 @@ html, body {
 		flex-basis: 100%;
 		width: 100%;
 	}
-	
+
 	.footer__logo {
 		margin-left: auto;
 		margin-right: auto;
 	}
-	
+
 	.footer__description {
 		margin: auto;
 	}
@@ -1615,7 +1662,7 @@ html, body {
 		flex-basis: 100%;
 		margin-bottom: 20px;
 	}
-	
+
 	.footer__bottom {
 		flex-direction: column-reverse;
 		gap: 15px;
@@ -1625,70 +1672,123 @@ html, body {
 	.search-filter__bar {
 		flex-direction: column;
 	}
-	
+
 	.search-filter__select {
 		width: 100%;
-	    padding: 10px 36px 10px 16px;
+		padding: 10px 36px 10px 16px;
 	}
-	
+
 	.search-filter__select-wrapper {
 		border-right: none;
 		border-bottom: 1px solid #e5e7eb;
 	}
-	
+
 	.search-filter__input {
 		padding: 14px 16px;
 	}
-	
+
 	.pagination {
-		gap:0;
+		gap: 0;
 	}
-	
+
 	.pagination__link {
 		font-size: 0.8rem;
-        padding: 6px 12px;
+		padding: 6px 12px;
 	}
-	
+
 	.detail__header {
 		flex-direction: column;
 		align-items: flex-start;
 		gap: 8px;
 	}
-	
+
 	.detail__badge {
 		align-self: flex-start;
 	}
-	
+
 	.detail__title {
 		font-size: 16px;
 	}
-	
+
 	.detail__divider {
 		margin: 0 -20px 16px;
 	}
-	
+
 	.detail__actions {
 		flex-direction: column;
 		gap: 8px;
 	}
-	
+
 	.detail__action-button {
 		width: 100%;
 		justify-content: center;
 	}
-	
+
 	/* 아코디언 반응형 */
 	.accordion-list__item-header {
 		padding: 16px 20px;
 	}
-	
+
 	.accordion-list__col {
 		font-size: 0.9rem;
 	}
-	
+
 	.accordion-list__item-content.is-active {
 		padding: 16px 20px;
 	}
+}
+
+/* 브레드 크럼 컨테이너 스타일 */
+.breadcrumb-container {
+	padding: 10px 0;
+}
+
+/* Flexbox를 사용하여 항목을 가로로 나열 */
+.breadcrumb {
+	display: flex;
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+/* 각 항목의 스타일 */
+.breadcrumb-item {
+	font-size: 14px;
+}
+
+/* 폰트 어썸 아이콘을 사용한 구분 기호 */
+.breadcrumb-item+.breadcrumb-item::before {
+	font-family: 'Font Awesome 5 Free';
+	/* 폰트 어썸 폰트 지정 */
+	font-weight: 900;
+	/* 폰트 굵기 지정 (필수) */
+	content: '\f054';
+	/* 꺽쇠(>) 아이콘의 유니코드 */
+	padding: 0 8px;
+	color: #999;
+}
+
+/* 마지막 활성화된 항목의 스타일 */
+.breadcrumb-item.active {
+	color: #333;
+	font-weight: bold;
+}
+
+/* 링크 스타일 */
+.breadcrumb-item a {
+	font-size: 16px;
+	text-decoration: none;
+	color: black;
+}
+
+.breadcrumb-item a:hover {
+	text-decoration: underline;
+}
+
+.breadcrumb-container-space {
+	max-width: 1160px;
+	width: 90%;
+	margin: 30px auto 0 auto;
 }
 
 .list-header__meta-item--source {

--- a/src/main/resources/static/js/account/join.js
+++ b/src/main/resources/static/js/account/join.js
@@ -5,22 +5,18 @@
 let isEmailVerified = false;
 let isNicknameValid = false;
 let isPasswordValid = false;
-let isNameValid = false;
+/*let isNameValid = false;*/
 let isReqCheck = false;
-let isInfoCheck = false;
-// 	let isPhoneValid = false;
+let isPhoneValid = false;
+let isInfoReqCheck = false;
 
-
+const joinBtn = document.getElementById('joinBtn');
 const phoneAccessBtn = document.getElementById('phoneAccess');
-const submitBtn = document.querySelector(".btn-signup");
 
+const submitBtn = document.getElementById('joinBtn');
 
 phoneAccessBtn.addEventListener('click', function() {
-	axios.post('/join/identityCheck.do').then(res => {
-
-	})
-
-	/*phoneAccess();*/
+	phoneAccess();
 })
 
 
@@ -41,31 +37,61 @@ function phoneAccess() {
 		function(rsp) {
 			// callback
 			if (rsp.success) {
-				console.log('인증 성공', rsp.imp_uid);
 				axios.post('/join/identityCheck.do', {
 
 					imp_uid: rsp.imp_uid
 
+				}).then(res => {
+					console.log(res.data);
+					const data = res.data.data;
+					const userName = document.getElementById('name');
+					const userPhone = document.getElementById('phone');
+					const userBirth = document.getElementById('birth');
+					const userGen = document.getElementById('gen');
+
+					userName.value = data.name;
+					userPhone.value = data.phone;
+					userBirth.value = data.birthday;
+					userGen.value = convertGenderToCode(data.gender);
+					isPhoneValid = true;
+
 				})
 
 			} else {
-				// 인증 실패 시 로직
-				console.log('인증 실패', rsp);
+				showConfirm2('본인인증에 실패하였습니다.',
+					() => {
+						return;
+					},
+					() => {
+
+					}
+				);
+				return;
 			}
 		},
 	);
 }
 
+function convertGenderToCode(gender) {
+
+	const lowerCaseGender = gender.toLowerCase();
+	if (lowerCaseGender === 'male') {
+		return 'G11001';
+	} else if (lowerCaseGender === 'female') {
+		return 'G11002';
+	} else {
+		return null;
+	}
+}
 function updateSubmitButtonState() {
 
-	console.log(isEmailVerified);
-	console.log(isNicknameValid);
-	console.log(isPasswordValid);
-	console.log(isNameValid);
-	console.log(isReqCheck);
-	console.log(isInfoCheck);
+	console.log("이메일", isEmailVerified);
+	console.log("닉네임", isNicknameValid);
+	console.log("비밀번호", isPasswordValid);
+	console.log("이용약관", isReqCheck);
+	console.log("전화번호", isPhoneValid);
 
-	const allValid = isEmailVerified && isNicknameValid && isPasswordValid && isNameValid && isReqCheck && isInfoCheck;
+	const allValid = isEmailVerified && isNicknameValid && isPasswordValid && isReqCheck && isPhoneValid && isInfoReqCheck;
 
 	submitBtn.disabled = !allValid;
 
@@ -80,14 +106,14 @@ chkTerms.addEventListener("change", () => {
 });
 
 chkPrivacy.addEventListener("change", () => {
-	isInfoCheck = chkPrivacy.checked;
+	isInfoReqCheck = chkPrivacy.checked;
 	updateSubmitButtonState();
 });
 
 const nameInput = document.getElementById("name");
 const nameError = document.getElementById("nameError");
 
-nameInput.addEventListener("input", () => {
+/*nameInput.addEventListener("input", () => {
 	const name = nameInput.value.trim();
 	const nameRegex = /^[가-힣a-zA-Z]{2,20}$/;
 
@@ -105,7 +131,7 @@ nameInput.addEventListener("input", () => {
 		isNameValid = true;
 	}
 	updateSubmitButtonState();
-});
+});*/
 
 
 const passwordInput = document.getElementById("password");
@@ -311,11 +337,12 @@ nicknameCheck.addEventListener("click", () => {
 				nicknameError.className = "nickname-message success";
 				nicknameError.textContent = "사용 가능한 닉네임입니다.";
 				isNicknameValid = true;
-
 			}
 		})
 		.catch(err => {
 			console.error(err);
 			nicknameError.textContent = "닉네임 중복 확인 중 오류 발생";
 		});
+
+
 });

--- a/src/main/resources/static/js/account/join.js
+++ b/src/main/resources/static/js/account/join.js
@@ -21,8 +21,6 @@ phoneAccessBtn.addEventListener('click', function() {
 
 
 function phoneAccess() {
-	console.log("phoneAccess 진입");
-
 	IMP.init("imp52856231");
 
 	IMP.certification(
@@ -42,7 +40,6 @@ function phoneAccess() {
 					imp_uid: rsp.imp_uid
 
 				}).then(res => {
-					console.log(res.data);
 					const data = res.data.data;
 					const userName = document.getElementById('name');
 					const userPhone = document.getElementById('phone');
@@ -84,13 +81,6 @@ function convertGenderToCode(gender) {
 	}
 }
 function updateSubmitButtonState() {
-
-	console.log("이메일", isEmailVerified);
-	console.log("닉네임", isNicknameValid);
-	console.log("비밀번호", isPasswordValid);
-	console.log("이용약관", isReqCheck);
-	console.log("전화번호", isPhoneValid);
-
 	const allValid = isEmailVerified && isNicknameValid && isPasswordValid && isReqCheck && isPhoneValid && isInfoReqCheck;
 
 	submitBtn.disabled = !allValid;
@@ -112,27 +102,6 @@ chkPrivacy.addEventListener("change", () => {
 
 const nameInput = document.getElementById("name");
 const nameError = document.getElementById("nameError");
-
-/*nameInput.addEventListener("input", () => {
-	const name = nameInput.value.trim();
-	const nameRegex = /^[가-힣a-zA-Z]{2,20}$/;
-
-	if (name === "") {
-		nameError.className = "name-message error";
-		nameError.textContent = "이름을 입력해주세요.";
-		isNameValid = false;
-	} else if (!nameRegex.test(name)) {
-		nameError.className = "name-message error";
-		nameError.textContent = "이름은 공백 없이 한글 또는 영문 2~20자로 입력해주세요.";
-		isNameValid = false;
-	} else {
-		nameError.className = "name-message success";
-		nameError.textContent = "사용 가능한 이름입니다.";
-		isNameValid = true;
-	}
-	updateSubmitButtonState();
-});*/
-
 
 const passwordInput = document.getElementById("password");
 const passwordConfirmInput = document.getElementById("passwordConfirm");
@@ -198,7 +167,6 @@ function emailCheck() {
 	})
 		.then(response => response.text())
 		.then(result => {
-			console.log(result)
 			if (result === "failed") {
 				emailError.className = "email-message error";
 				emailError.textContent = "중복된 이메일입니다.";
@@ -238,12 +206,18 @@ function showEmailModal(email) {
 		})
 			.then(res => res.text())
 			.then(result => {
-				console.log(result);
 				if (result === "sendOk") {
 					startTimer(180); // 3분
 					document.getElementById("authCodeBox").style.display = "block";
 				} else {
-					alert("메일 전송 실패");
+					showConfirm2('메일전송 실패.',
+						() => {
+							return;
+						},
+						() => {
+
+						}
+					);
 				}
 			})
 			.catch(err => {
@@ -279,7 +253,14 @@ closeBtn.onclick = () => {
 document.getElementById("verifyCodeBtn").onclick = () => {
 	const code = document.getElementById("authCodeInput").value.trim();
 	if (!code) {
-		showCustomAlert("인증코드를 입력해주세요.");
+		showConfirm2('인증코드를 입력해주세요.',
+			() => {
+				return;
+			},
+			() => {
+
+			}
+		);
 		return;
 	}
 
@@ -291,12 +272,25 @@ document.getElementById("verifyCodeBtn").onclick = () => {
 		.then(res => res.text())
 		.then(result => {
 			if (result === "success") {
-				alert("인증 완료");
+				showConfirm2('인증을 성공했습니다.',
+					() => {
+						return;
+					},
+					() => {
+					}
+				);
+
 				modal.style.display = "none";
 				clearInterval(timerInterval);
 				isEmailVerified = true;
 			} else {
-				showCustomAlert("인증 실패! 코드를 다시 확인해주세요.");
+				showConfirm2('인증을 실패했습니다.',
+					() => {
+						return;
+					},
+					() => {
+					}
+				);
 			}
 		});
 };
@@ -366,7 +360,7 @@ nicknameCheck.addEventListener("click", () => {
 		hiddenInput.name = 'memAlarm';
 		hiddenInput.value = promotionCode;
 		form.appendChild(hiddenInput);
-		
+
 		form.submit();
 	});
 });

--- a/src/main/resources/static/js/account/join.js
+++ b/src/main/resources/static/js/account/join.js
@@ -344,5 +344,29 @@ nicknameCheck.addEventListener("click", () => {
 			nicknameError.textContent = "닉네임 중복 확인 중 오류 발생";
 		});
 
+	document.getElementById('joinBtn').addEventListener('click', function(e) {
+		e.preventDefault();
 
+		let promotionCode = 'G12001';
+
+		const mailChecked = document.querySelector('input[value="mail"]').checked;
+		const kakaoChecked = document.querySelector('input[value="kakao"]').checked;
+
+		if (mailChecked && kakaoChecked) {
+			promotionCode = 'G12004';
+		} else if (mailChecked) {
+			promotionCode = 'G12002';
+		} else if (kakaoChecked) {
+			promotionCode = 'G12003';
+		}
+
+		const form = document.querySelector('form');
+		const hiddenInput = document.createElement('input');
+		hiddenInput.type = 'hidden';
+		hiddenInput.name = 'memAlarm';
+		hiddenInput.value = promotionCode;
+		form.appendChild(hiddenInput);
+		
+		form.submit();
+	});
 });

--- a/src/main/resources/static/js/account/join.js
+++ b/src/main/resources/static/js/account/join.js
@@ -3,275 +3,319 @@
  */
 
 let isEmailVerified = false;
-	let isNicknameValid = false;
-	let isPasswordValid = false;
-	let isNameValid = false;
-	let isReqCheck = false;
-	let isInfoCheck = false;
+let isNicknameValid = false;
+let isPasswordValid = false;
+let isNameValid = false;
+let isReqCheck = false;
+let isInfoCheck = false;
 // 	let isPhoneValid = false;
 
-	const submitBtn = document.querySelector(".btn-signup");
 
-	function updateSubmitButtonState() {
-	  
-      console.log(isEmailVerified);
-      console.log(isNicknameValid);
-      console.log(isPasswordValid);
-      console.log(isNameValid);
-      console.log(isReqCheck);
-      console.log(isInfoCheck);
-	  
-	  const allValid = isEmailVerified && isNicknameValid && isPasswordValid && isNameValid && isReqCheck && isInfoCheck;
-	  
-	  submitBtn.disabled = !allValid;
-	  
+const phoneAccessBtn = document.getElementById('phoneAccess');
+const submitBtn = document.querySelector(".btn-signup");
+
+
+phoneAccessBtn.addEventListener('click', function() {
+	axios.post('/join/identityCheck.do').then(res => {
+
+	})
+
+	/*phoneAccess();*/
+})
+
+
+function phoneAccess() {
+	console.log("phoneAccess 진입");
+
+	IMP.init("imp52856231");
+
+	IMP.certification(
+		{
+			// param
+			channelKey: "channel-key-bf054284-0b27-4e7e-b48e-49e954bef4dc",
+			// 주문 번호
+			merchant_uid: "ORD20180131-0000011",
+			// PC환경에서는 popup 파라미터가 무시되고 항상 true 로 적용됨
+			popup: false,
+		},
+		function(rsp) {
+			// callback
+			if (rsp.success) {
+				console.log('인증 성공', rsp.imp_uid);
+				axios.post('/join/identityCheck.do', {
+
+					imp_uid: rsp.imp_uid
+
+				})
+
+			} else {
+				// 인증 실패 시 로직
+				console.log('인증 실패', rsp);
+			}
+		},
+	);
+}
+
+function updateSubmitButtonState() {
+
+	console.log(isEmailVerified);
+	console.log(isNicknameValid);
+	console.log(isPasswordValid);
+	console.log(isNameValid);
+	console.log(isReqCheck);
+	console.log(isInfoCheck);
+
+	const allValid = isEmailVerified && isNicknameValid && isPasswordValid && isNameValid && isReqCheck && isInfoCheck;
+
+	submitBtn.disabled = !allValid;
+
+}
+
+const chkTerms = document.getElementById("reqchk");
+const chkPrivacy = document.getElementById("infochk");
+
+chkTerms.addEventListener("change", () => {
+	isReqCheck = chkTerms.checked;
+	updateSubmitButtonState();
+});
+
+chkPrivacy.addEventListener("change", () => {
+	isInfoCheck = chkPrivacy.checked;
+	updateSubmitButtonState();
+});
+
+const nameInput = document.getElementById("name");
+const nameError = document.getElementById("nameError");
+
+nameInput.addEventListener("input", () => {
+	const name = nameInput.value.trim();
+	const nameRegex = /^[가-힣a-zA-Z]{2,20}$/;
+
+	if (name === "") {
+		nameError.className = "name-message error";
+		nameError.textContent = "이름을 입력해주세요.";
+		isNameValid = false;
+	} else if (!nameRegex.test(name)) {
+		nameError.className = "name-message error";
+		nameError.textContent = "이름은 공백 없이 한글 또는 영문 2~20자로 입력해주세요.";
+		isNameValid = false;
+	} else {
+		nameError.className = "name-message success";
+		nameError.textContent = "사용 가능한 이름입니다.";
+		isNameValid = true;
 	}
-	
-	const chkTerms = document.getElementById("reqchk");
-	const chkPrivacy = document.getElementById("infochk");
+	updateSubmitButtonState();
+});
 
-	chkTerms.addEventListener("change", () => {
-	  isReqCheck = chkTerms.checked;
-	  updateSubmitButtonState();
-	});
 
-	chkPrivacy.addEventListener("change", () => {
-	  isInfoCheck = chkPrivacy.checked;
-	  updateSubmitButtonState();
-	});
-	
-	const nameInput = document.getElementById("name");
-	const nameError = document.getElementById("nameError");
+const passwordInput = document.getElementById("password");
+const passwordConfirmInput = document.getElementById("passwordConfirm");
+const errorMsg = document.getElementById("pwMismatchMsg");
 
-	nameInput.addEventListener("input", () => {
-	  const name = nameInput.value.trim();
-	  const nameRegex = /^[가-힣a-zA-Z]{2,20}$/;
+passwordConfirmInput.addEventListener("input", function() {
 
-	  if (name === "") {
-	    nameError.className = "name-message error";
-	    nameError.textContent = "이름을 입력해주세요.";
-	    isNameValid = false;
-	  } else if (!nameRegex.test(name)) {
-	    nameError.className = "name-message error";
-	    nameError.textContent = "이름은 공백 없이 한글 또는 영문 2~20자로 입력해주세요.";
-	    isNameValid = false;
-	  } else {
-	    nameError.className = "name-message success";
-	    nameError.textContent = "사용 가능한 이름입니다.";
-	    isNameValid = true;
-	  }
-	  updateSubmitButtonState();
-	});
-	
-	
-	const passwordInput = document.getElementById("password");
-	const passwordConfirmInput = document.getElementById("passwordConfirm");
-	const errorMsg = document.getElementById("pwMismatchMsg");
+	const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()\-_=+{};:,<.>]).{8,}$/;
 
-	passwordConfirmInput.addEventListener("input", function () {
-		
-	  const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()\-_=+{};:,<.>]).{8,}$/;
-		
-	  const pw = passwordInput.value;
-	  const pwConfirm = passwordConfirmInput.value;
-	  
-	  if (pw === "" && pwConfirm === ""){
+	const pw = passwordInput.value;
+	const pwConfirm = passwordConfirmInput.value;
+
+	if (pw === "" && pwConfirm === "") {
 		passwordError.className = "password-message error";
 		passwordError.textContent = "";
 		isPasswordValid = false;
-	  }
-	  else if (!passwordRegex.test(pw)) {
-	    passwordError.className = "password-message error";
-	    passwordError.textContent = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다.";
-	    isPasswordValid = false;
-	  }
-	  else if (pw !== pwConfirm) {  
+	}
+	else if (!passwordRegex.test(pw)) {
+		passwordError.className = "password-message error";
+		passwordError.textContent = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다.";
+		isPasswordValid = false;
+	}
+	else if (pw !== pwConfirm) {
 		passwordError.className = "password-message error";
 		passwordError.textContent = "비밀번호가 일치하지않습니다.";
 		isPasswordValid = false;
-	  } 
-	  else {
+	}
+	else {
 		passwordError.className = "password-message success";
 		passwordError.textContent = "사용 가능한 비밀번호 입니다.";
 		isPasswordValid = true;
-	  }
-	  updateSubmitButtonState();
-	  
-	});
-	
-	function emailCheck() {
-		const emailInput = document.getElementById("email");
-		const email = emailInput.value.trim();
-
-		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-		if (email === "") {
-			emailError.className = "email-message error";
-			emailError.textContent = "이메일을 입력해주세요.";
-			emailInput.focus();
-			return;
-		}
-
-		if (!emailRegex.test(email)) {
-			emailError.className = "email-message error";
-			emailError.textContent = "올바른 이메일 형식이 아닙니다.";
-			emailInput.focus();
-			return;
-		}
-		
-		fetch("/join/emailCheck.do", {
-			  method: "POST",
-			  headers: {
-			    "Content-Type": "application/json",
-			  },
-			  body: JSON.stringify({ email: email })
-			})
-			.then(response => response.text())
-			.then(result => {
-				console.log(result)
-			  if (result === "failed") {
-				  	emailError.className = "email-message error";
-					emailError.textContent = "중복된 이메일입니다.";
-					emailInput.focus();
-			  } else if (result === "access") {
-				  emailError.className = "email-message success";
-				  emailError.textContent = " ";
-				  showEmailModal(email);
-			  }
-			})
-			.catch(error => {
-			  console.error("이메일 중복 확인 오류:", error);
-			  message.textContent = "서버 오류가 발생했습니다.";
-			  message.style.color = "red";
-			});
 	}
-	
-	const modal = document.getElementById("emailModal");
-	const closeBtn = document.querySelector(".close");
-	const sendBtn = document.getElementById("sendEmailBtn");
-	const timerEl = document.getElementById("timer");
+	updateSubmitButtonState();
 
-	let timerInterval;
+});
 
-	function showEmailModal(email) {
-	  document.getElementById("userEmailInfo").textContent = `${email}`;
-	  modal.style.display = "block";
+function emailCheck() {
+	const emailInput = document.getElementById("email");
+	const email = emailInput.value.trim();
 
-	  sendBtn.onclick = () => {
+	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+	if (email === "") {
+		emailError.className = "email-message error";
+		emailError.textContent = "이메일을 입력해주세요.";
+		emailInput.focus();
+		return;
+	}
+
+	if (!emailRegex.test(email)) {
+		emailError.className = "email-message error";
+		emailError.textContent = "올바른 이메일 형식이 아닙니다.";
+		emailInput.focus();
+		return;
+	}
+
+	fetch("/join/emailCheck.do", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ email: email })
+	})
+		.then(response => response.text())
+		.then(result => {
+			console.log(result)
+			if (result === "failed") {
+				emailError.className = "email-message error";
+				emailError.textContent = "중복된 이메일입니다.";
+				emailInput.focus();
+			} else if (result === "access") {
+				emailError.className = "email-message success";
+				emailError.textContent = " ";
+				showEmailModal(email);
+			}
+		})
+		.catch(error => {
+			console.error("이메일 중복 확인 오류:", error);
+			message.textContent = "서버 오류가 발생했습니다.";
+			message.style.color = "red";
+		});
+}
+
+const modal = document.getElementById("emailModal");
+const closeBtn = document.querySelector(".close");
+const sendBtn = document.getElementById("sendEmailBtn");
+const timerEl = document.getElementById("timer");
+
+let timerInterval;
+
+function showEmailModal(email) {
+	document.getElementById("userEmailInfo").textContent = `${email}`;
+	modal.style.display = "block";
+
+	sendBtn.onclick = () => {
 		sendBtn.disabled = true;
 		sendBtn.textContent = "전송 중...";
-		  
-	    fetch("/join/sendMail.do", {
-	      method: "POST",
-	      headers: { "Content-Type": "application/json" },
-	      body: JSON.stringify({ email: email })
-	    })
-	    .then(res => res.text())
-	    .then(result => {
-	    	console.log(result);
-	      if (result === "sendOk") {
-	        startTimer(180); // 3분
-	        document.getElementById("authCodeBox").style.display = "block";
-	      } else {
-	        alert("메일 전송 실패");
-	      }
-	    })
-	    .catch(err => {
-	        alert("서버 오류가 발생했습니다.");
-	      })
-	      .finally(() => {
-	        sendBtn.disabled = false;
-	        sendBtn.textContent = "인증 메일 전송";
-	      })
-	  };
-	}
 
-	function startTimer(duration) {
-	  let time = duration;
-	  clearInterval(timerInterval);
-
-	  timerInterval = setInterval(() => {
-	    const minutes = String(Math.floor(time / 60)).padStart(2, '0');
-	    const seconds = String(time % 60).padStart(2, '0');
-	    timerEl.textContent = `인증 제한시간: ${minutes}:${seconds}`;
-
-	    if (--time < 0) {
-	      clearInterval(timerInterval);
-	      timerEl.textContent = "인증 시간이 만료되었습니다.";
-	    }
-	  }, 1000);
-	}
-
-	closeBtn.onclick = () => {
-	  modal.style.display = "none";
-	  clearInterval(timerInterval);
-	};
-	document.getElementById("verifyCodeBtn").onclick = () => {
-		  const code = document.getElementById("authCodeInput").value.trim();
-		  if (!code) {
-		    showCustomAlert("인증코드를 입력해주세요.");
-		    return;
-		  }
-
-		  fetch("/join/verify.do", {
-		    method: "POST",
-		    headers: { "Content-Type": "application/json" },
-		    body: JSON.stringify({ email: email, code: code })
-		  })
-		  .then(res => res.text())
-		  .then(result => {
-		    if (result === "success") {
-		      alert("인증 완료");
-		      modal.style.display = "none";
-		      clearInterval(timerInterval);
-		      isEmailVerified = true;
-		    } else {
-		      showCustomAlert("인증 실패! 코드를 다시 확인해주세요.");
-		    }
-		  });
-		};
-		
-	const nicknameCheck = document.getElementById("nicknameCheck");
-	const nicknameInput = document.getElementById("nickname");
-	const nicknameError = document.getElementById("nicknameError");
-
-	nicknameCheck.addEventListener("click", () => {
-	  const nickname = nicknameInput.value.trim();
-
-	  const nicknameRegex = /^[가-힣a-zA-Z0-9]{2,10}$/;
-
-	  if (!nickname) {
-	    nicknameError.textContent = "닉네임을 입력해주세요.";
-	    nicknameError.className = "nickname-message error";
-	    
-	    return;
-	  }
-
-	  if (!nicknameRegex.test(nickname)) {
-		nicknameError.className = "nickname-message error";
-	    nicknameError.textContent = "닉네임은 한글, 영문, 숫자 조합 2~10자로 입력해주세요.";
-	    return;
-	  }
-	  
-	  fetch("/join/checkNickname.do", {
-		  method: "POST",
-		  headers: { "Content-Type": "application/json" },
-		  body: JSON.stringify({ nickname })
+		fetch("/join/sendMail.do", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: email })
 		})
-		  .then(res => res.json())
-		  .then(result => {
-		    if (result.duplicate) {
-		      nicknameError.className = "nickname-message error";
-		      nicknameError.textContent = "이미 사용 중인 닉네임입니다.";
-		    } else {
-		      nicknameError.className = "nickname-message success";
-		      nicknameError.textContent = "사용 가능한 닉네임입니다.";
-		      isNicknameValid = true;
-		      
-		    }
-		  })
-		  .catch(err => {
-		    console.error(err);
-		    nicknameError.textContent = "닉네임 중복 확인 중 오류 발생";
-		  });
-	});
+			.then(res => res.text())
+			.then(result => {
+				console.log(result);
+				if (result === "sendOk") {
+					startTimer(180); // 3분
+					document.getElementById("authCodeBox").style.display = "block";
+				} else {
+					alert("메일 전송 실패");
+				}
+			})
+			.catch(err => {
+				alert("서버 오류가 발생했습니다.");
+			})
+			.finally(() => {
+				sendBtn.disabled = false;
+				sendBtn.textContent = "인증 메일 전송";
+			})
+	};
+}
+
+function startTimer(duration) {
+	let time = duration;
+	clearInterval(timerInterval);
+
+	timerInterval = setInterval(() => {
+		const minutes = String(Math.floor(time / 60)).padStart(2, '0');
+		const seconds = String(time % 60).padStart(2, '0');
+		timerEl.textContent = `인증 제한시간: ${minutes}:${seconds}`;
+
+		if (--time < 0) {
+			clearInterval(timerInterval);
+			timerEl.textContent = "인증 시간이 만료되었습니다.";
+		}
+	}, 1000);
+}
+
+closeBtn.onclick = () => {
+	modal.style.display = "none";
+	clearInterval(timerInterval);
+};
+document.getElementById("verifyCodeBtn").onclick = () => {
+	const code = document.getElementById("authCodeInput").value.trim();
+	if (!code) {
+		showCustomAlert("인증코드를 입력해주세요.");
+		return;
+	}
+
+	fetch("/join/verify.do", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ email: email, code: code })
+	})
+		.then(res => res.text())
+		.then(result => {
+			if (result === "success") {
+				alert("인증 완료");
+				modal.style.display = "none";
+				clearInterval(timerInterval);
+				isEmailVerified = true;
+			} else {
+				showCustomAlert("인증 실패! 코드를 다시 확인해주세요.");
+			}
+		});
+};
+
+const nicknameCheck = document.getElementById("nicknameCheck");
+const nicknameInput = document.getElementById("nickname");
+const nicknameError = document.getElementById("nicknameError");
+
+nicknameCheck.addEventListener("click", () => {
+	const nickname = nicknameInput.value.trim();
+
+	const nicknameRegex = /^[가-힣a-zA-Z0-9]{2,10}$/;
+
+	if (!nickname) {
+		nicknameError.textContent = "닉네임을 입력해주세요.";
+		nicknameError.className = "nickname-message error";
+
+		return;
+	}
+
+	if (!nicknameRegex.test(nickname)) {
+		nicknameError.className = "nickname-message error";
+		nicknameError.textContent = "닉네임은 한글, 영문, 숫자 조합 2~10자로 입력해주세요.";
+		return;
+	}
+
+	fetch("/join/checkNickname.do", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ nickname })
+	})
+		.then(res => res.json())
+		.then(result => {
+			if (result.duplicate) {
+				nicknameError.className = "nickname-message error";
+				nicknameError.textContent = "이미 사용 중인 닉네임입니다.";
+			} else {
+				nicknameError.className = "nickname-message success";
+				nicknameError.textContent = "사용 가능한 닉네임입니다.";
+				isNicknameValid = true;
+
+			}
+		})
+		.catch(err => {
+			console.error(err);
+			nicknameError.textContent = "닉네임 중복 확인 중 오류 발생";
+		});
+});

--- a/src/main/resources/static/js/account/login.js
+++ b/src/main/resources/static/js/account/login.js
@@ -37,6 +37,16 @@ async function kakaoLogin() {
 
   window.location.href = kakaoAuthURL;
 }
+document.addEventListener("DOMContentLoaded", () => {
+	checkRegist();
+})
+
+function checkRegist() {
+	const registMessage = document.querySelector("#public-wrapper-main-login").dataset.registMessage;
+	if(registMessage) {
+		alert(registMessage);
+	}
+}
 
 function loginBtn(){
 	

--- a/src/main/resources/static/js/empt/ivfb/interviewFeedback.js
+++ b/src/main/resources/static/js/empt/ivfb/interviewFeedback.js
@@ -3,7 +3,7 @@
  */
 
 document.addEventListener('DOMContentLoaded', function() {
-	const channelSection = document.querySelector(".channel");
+	const channelSection = document.querySelector(".breadcrumb-container-space");
 	if (channelSection) {
 	    const errorMessage = channelSection.dataset.errorMessage;
 	    if (errorMessage) {

--- a/src/main/resources/static/js/ertds/univ/uvsrch/univDetail.js
+++ b/src/main/resources/static/js/ertds/univ/uvsrch/univDetail.js
@@ -107,7 +107,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // 초기화 함수들 실행
     initializeSearchListeners();
-    initializeDeptLinkListeners();
 	processCompetitionRates();
 
     // 페이지 로드 완료 시 검색창에 포커스 (선택사항)

--- a/src/main/resources/static/js/mpg/mif/inq/selectMyInquiryView.js
+++ b/src/main/resources/static/js/mpg/mif/inq/selectMyInquiryView.js
@@ -3,13 +3,13 @@
  */
 
 document.addEventListener("DOMContentLoaded", () => {
-    const channelSection = document.querySelector(".channel");
-    if (channelSection) {
-        const successMessage = channelSection.dataset.successMessage;
-        const errorMessage = channelSection.dataset.errorMessage;
-        if (successMessage) alert(successMessage);
-        if (errorMessage) alert(errorMessage);
-    }
+	const channelSection = document.querySelector(".public-wrapper");
+	if (channelSection) {
+		const successMessage = channelSection.dataset.successMessage;
+		const errorMessage = channelSection.dataset.errorMessage;
+		if (successMessage) alert(successMessage);
+		if (errorMessage) alert(errorMessage);
+	}
 
 	try {
 		if (memId == "anonymousUser") {
@@ -22,7 +22,7 @@ document.addEventListener("DOMContentLoaded", () => {
 	}
 
 	const moveSubBtn = document.querySelector("#move-sub-btn");
-	if(moveSubBtn) {
+	if (moveSubBtn) {
 		moveSubBtn.addEventListener("click", () => {
 			location.href = "/mpg/pay/selectPaymentView.do";
 		});
@@ -44,7 +44,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
 const handleImgFileSelect = (event) => {
 	const files = event.target.files;
-    const profileImg = document.querySelector(".profile-img");
+	const profileImg = document.querySelector(".profile-img");
 
 	if (files.length === 0) {
 		alert("파일이 선택되지 않았습니다.");
@@ -67,17 +67,17 @@ const handleImgFileSelect = (event) => {
 	}).then(response => {
 		return response.json();
 	}).then(result => {
-        if (result.status === "success") {
-            alert(result.message);
-            if(profileImg) profileImg.src = result.imgPath; // 이미지 즉시 업데이트
-        } else {
-            alert(result.message || "프로필 사진 변경에 실패했습니다.");
-        }
-    })
-    .catch(error => {
-        console.error("프로필 이미지 업로드 중 에러 발생 : ", error);
-        alert("업로드 중 오류가 발생했습니다.");
-    });
+		if (result.status === "success") {
+			alert(result.message);
+			if (profileImg) profileImg.src = result.imgPath; // 이미지 즉시 업데이트
+		} else {
+			alert(result.message || "프로필 사진 변경에 실패했습니다.");
+		}
+	})
+		.catch(error => {
+			console.error("프로필 이미지 업로드 중 에러 발생 : ", error);
+			alert("업로드 중 오류가 발생했습니다.");
+		});
 }
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -108,14 +108,14 @@ document.addEventListener("DOMContentLoaded", () => {
 		errorMsg.textContent = '';
 	};
 
-	submitBtn.addEventListener('click', function (event) {
+	submitBtn.addEventListener('click', function(event) {
 		event.preventDefault();
 		openModal();
 	});
 
 	closeModalBtn.addEventListener('click', closeModal);
 
-	modalOverlay.addEventListener('click', function (event) {
+	modalOverlay.addEventListener('click', function(event) {
 		if (event.target === modalOverlay) {
 			closeModal();
 		}
@@ -161,30 +161,30 @@ const passwordCheckAPI = (password, errorMsg, passwordInput, closeModal) => {
 	}).then(response => {
 		return response.json()
 	}).then(result => {
-        if (result.status === "success") {
+		if (result.status === "success") {
 			closeModal();
-			
+
 			if (!nicknameRegex.test(nickname)) {
 				alert("닉네임은 한글, 영문, 숫자 조합 2~10자로 입력해주세요.");
 				return;
 			}
-			
+
 			if (!nameRegex.test(name)) {
 				alert("이름은 공백 없이 한글 또는 영문 2~20자로 입력해주세요.");
 				return;
 			}
 
-            mainForm.submit();
-        } else {
-            errorMsg.textContent = result.message || '비밀번호가 일치하지 않습니다.';
-            passwordInput.value = ''; // 입력 필드 초기화
-            passwordInput.focus();
-        }
-    })
-    .catch(error => {
-        console.error("비밀번호 인증 에러 :", error);
-        errorMsg.textContent = '인증 중 오류가 발생했습니다. 다시 시도해 주세요.';
-    });
+			mainForm.submit();
+		} else {
+			errorMsg.textContent = result.message || '비밀번호가 일치하지 않습니다.';
+			passwordInput.value = ''; // 입력 필드 초기화
+			passwordInput.focus();
+		}
+	})
+		.catch(error => {
+			console.error("비밀번호 인증 에러 :", error);
+			errorMsg.textContent = '인증 중 오류가 발생했습니다. 다시 시도해 주세요.';
+		});
 }
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -204,14 +204,14 @@ document.addEventListener("DOMContentLoaded", () => {
 		errorMsg.textContent = '';
 	};
 
-	interestsUpdateBtn.addEventListener('click', function (event) {
+	interestsUpdateBtn.addEventListener('click', function(event) {
 		event.preventDefault();
 		openModal();
 	});
 
 	closeModalBtn.addEventListener('click', closeModal);
 
-	modalOverlay.addEventListener('click', function (event) {
+	modalOverlay.addEventListener('click', function(event) {
 		if (event.target === modalOverlay) {
 			closeModal();
 		}
@@ -219,7 +219,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
 });
 
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', function() {
 	// 관심사 키워드 체크박스
 	const keywordCheckbox = document.querySelectorAll('.com-filter-item input[type="checkbox"]');
 
@@ -268,14 +268,58 @@ document.addEventListener('DOMContentLoaded', function () {
 	}
 
 	const checkboxes = document.querySelectorAll('input[name="filter-keyword"]');
-	
+
 	checkboxes.forEach((checkbox) => {
 		checkbox.addEventListener("click", (event) => {
 			const selectCheckbox = document.querySelectorAll('input[name="filter-keyword"]:checked');
-			if(selectCheckbox.length > 5) {
+			if (selectCheckbox.length > 5) {
 				alert("관심사 최대 5개 까지만 선택 가능합니다.");
 				event.target.checked = false;
 			}
 		});
 	});
+
+});
+document.addEventListener("DOMContentLoaded", () => {
+	const phoneChangeBtn = document.getElementById('phoneChangeBtn');
+
+	phoneChangeBtn.addEventListener('click', function() {
+		IMP.init("imp52856231");
+
+		IMP.certification(
+			{
+
+				channelKey: "channel-key-bf054284-0b27-4e7e-b48e-49e954bef4dc",
+				merchant_uid: "ORD20180131-0000011",
+				popup: false,
+			},
+			function(rsp) {
+				if (rsp.success) {
+					axios.post('/mpg/mif/inq/updateMemberPhone.do', {
+						imp_uid: rsp.imp_uid
+					}).then(res => {
+						showConfirm2(res.data,
+							() => {
+								return;
+							},
+							() => {
+
+							}
+						);
+						location.reload();
+					})
+				} else {
+					showConfirm2('본인인증에 실패하였습니다.',
+						() => {
+							return;
+						},
+						() => {
+
+						}
+					);
+					return;
+				}
+			},
+		);
+	})
 });

--- a/src/main/resources/static/js/pse/cr/crl/selectCareerList.js
+++ b/src/main/resources/static/js/pse/cr/crl/selectCareerList.js
@@ -1,5 +1,8 @@
 document.addEventListener('DOMContentLoaded', function() {
-	const channelSection = document.querySelector(".channel");
+	const channelSection = document.querySelector(".breadcrumb-container-space");
+	
+	console.log(channelSection);
+	
 	if (channelSection) {
 	    const errorMessage = channelSection.dataset.errorMessage;
 	    const serverError = channelSection.dataset.serverError;

--- a/src/main/webapp/WEB-INF/views/account/join.jsp
+++ b/src/main/webapp/WEB-INF/views/account/join.jsp
@@ -1,6 +1,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
 	pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
+<script src="https://cdn.iamport.kr/v1/iamport.js"></script>
 <link rel="stylesheet" href="/css/account/join/joinPage.css">
 <!-- 스타일 여기 적어주시면 가능 -->
 
@@ -75,7 +76,7 @@
 						<div class="input-row">
 							<label for="phone">핸드폰 번호</label> <input type="tel"
 								class="inputWt" id="phone" placeholder="핸드폰 번호를 입력해주세요." />
-							<button type="button">전화번호 인증</button>
+							<button type="button" id="phoneAccess">전화번호 인증</button>
 						</div>
 
 						<!-- 						<div class="input-gen"> -->
@@ -123,7 +124,7 @@
 		</div>
 	</div>
 </div>
-</div>
+
 <%@ include file="/WEB-INF/views/include/footer.jsp"%>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/account/join.jsp
+++ b/src/main/webapp/WEB-INF/views/account/join.jsp
@@ -75,8 +75,8 @@
 							<input class="inputWt2" type="text" id="name" readonly="readonly" name="memName" placeholder="전화번호 인증을 해주세요." />
 						</div>
 						<p id="nameError"></p>
-						<input class="inputWt2" type="text" id="birth" readonly="readonly" name="memBirth" />
-						<input class="inputWt2" type="text" id="gen" readonly="readonly" name="memGen"/>
+						<input class="inputWt2" type="hidden" id="birth" readonly="readonly" name="memBirth" />
+						<input class="inputWt2" type="hidden" id="gen" readonly="readonly" name="memGen"/>
 						<!-- 						<div class="input-gen"> -->
 						<!-- 							<div class="gender-wt">성별</div> -->
 						<!-- 							<div class="gender-row"> -->

--- a/src/main/webapp/WEB-INF/views/account/join.jsp
+++ b/src/main/webapp/WEB-INF/views/account/join.jsp
@@ -1,5 +1,4 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8"
-	pageEncoding="UTF-8"%>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <script src="https://cdn.iamport.kr/v1/iamport.js"></script>
 <link rel="stylesheet" href="/css/account/join/joinPage.css">
@@ -18,9 +17,7 @@
 			<div class="modal-content">
 				<span class="close">&times;</span>
 				<h2>이메일 인증</h2>
-				<p id="emailStatusMessage"
-					style="color: green; font-weight: 600; margin: 10px 0;">사용 가능한
-					이메일입니다.</p>
+				<p id="emailStatusMessage" style="color: green; font-weight: 600; margin: 10px 0;">사용 가능한 이메일입니다.</p>
 				<p id="userEmailInfo"></p>
 				<br />
 				<button id="sendEmailBtn">인증 메일 전송</button>
@@ -35,50 +32,51 @@
 			<div class="dpfx2">
 				<div class="signup-container2">
 					<div class="top-text">
-						<span>이미 커리어패스 회원이신가요?</span> <a href="/login">로그인</a>
+						<span>이미 커리어패스 회원이신가요?</span>
+						<a href="/login">로그인</a>
 					</div>
 				</div>
 			</div>
 			<div class="dpfx">
 				<div class="signup-container">
-					<form>
+					<form action="/join/memberJoin.do" method="post">
 						<div class="input-row">
-							<label for="email">이메일</label> <input class="inputWt"
-								type="email" id="email" placeholder="이메일을 입력해주세요." />
+							<label for="email">이메일</label>
+							<input class="inputWt" type="email" id="email" name="memEmail" placeholder="이메일을 입력해주세요." />
 							<button type="button" onclick="emailCheck()">이메일 인증</button>
 						</div>
 						<p id="emailError"></p>
 
 						<div class="input-row">
-							<label for="nickname">닉네임</label> <input type="text"
-								class="inputWt" id="nickname" placeholder="닉네임을 입력해주세요." />
+							<label for="nickname">닉네임</label>
+							<input type="text" class="inputWt" id="nickname" name="memNickName" placeholder="닉네임을 입력해주세요." />
 
 							<button id="nicknameCheck" type="button">중복 확인</button>
 						</div>
 						<p id="nicknameError"></p>
 
 						<div class="input-row2">
-							<label for="password">비밀번호</label> <input type="password"
-								class="inputWt2" class="line-flex" id="password"
-								placeholder="비밀번호를 입력해주세요." />
+							<label for="password">비밀번호</label>
+							<input type="password" class="inputWt2" class="line-flex" id="password" placeholder="비밀번호를 입력해주세요." />
 						</div>
+						<p id="tempSpace"></p>
 						<div class="input-row2">
-							<label for="passwordConfirm">비밀번호 확인</label> <input
-								class="inputWt2" type="password" id="passwordConfirm"
-								placeholder="비밀번호를 한 번 더 입력해주세요." />
+							<label for="passwordConfirm">비밀번호 확인</label>
+							<input class="inputWt2" type="password" id="passwordConfirm" name="memPassword" placeholder="비밀번호를 한 번 더 입력해주세요." />
 						</div>
 						<p id="passwordError"></p>
-						<div class="input-row2">
-							<label for="name">이름</label> <input class="inputWt2" type="text"
-								id="name" placeholder="이름을 입력해주세요." />
-						</div>
-						<p id="nameError"></p>
 						<div class="input-row">
-							<label for="phone">핸드폰 번호</label> <input type="tel"
-								class="inputWt" id="phone" placeholder="핸드폰 번호를 입력해주세요." />
+							<label for="phone">전화번호</label>
+							<input type="tel" class="inputWt" id="phone" readonly="readonly" name="memPhoneNumber" placeholder="전화번호 인증을 해주세요." />
 							<button type="button" id="phoneAccess">전화번호 인증</button>
 						</div>
-
+						<div class="input-row2">
+							<label for="name">이름</label>
+							<input class="inputWt2" type="text" id="name" readonly="readonly" name="memName" placeholder="전화번호 인증을 해주세요." />
+						</div>
+						<p id="nameError"></p>
+						<input class="inputWt2" type="text" id="birth" readonly="readonly" name="memBirth" />
+						<input class="inputWt2" type="text" id="gen" readonly="readonly" name="memGen"/>
 						<!-- 						<div class="input-gen"> -->
 						<!-- 							<div class="gender-wt">성별</div> -->
 						<!-- 							<div class="gender-row"> -->
@@ -93,29 +91,41 @@
 
 						<div class="checkboxes">
 							<div class="reqAgree">
-								<label><input id="reqchk" type="checkbox" /> 이용약관 동의 <span
-									class="minimal" style="color: red;">필수</span></label>
+								<label>
+									<input id="reqchk" type="checkbox" />
+									이용약관 동의
+									<span class="minimal" style="color: red;">필수</span>
+								</label>
 								<div class="agreeBorder">내용보기</div>
 							</div>
 
 							<div class="solAgree">
-								<label><input id="infochk" type="checkbox" /> 개인정보 수집 및 이용 동의 <span
-									class="minimal" style="color: red;">필수</span></label>
+								<label>
+									<input id="infochk" type="checkbox" />
+									개인정보 수집 및 이용 동의
+									<span class="minimal" style="color: red;">필수</span>
+								</label>
 								<div class="agreeBorder">내용보기</div>
 							</div>
 							<div class="eventAgree">
-								<label><input type="checkbox" /> 이벤트 등 프로모션 메일 수신 동의 <span
-									class="minimal">선택</span></label>
+								<label>
+									<input type="checkbox" />
+									이벤트 등 프로모션 메일 수신 동의
+									<span class="minimal">선택</span>
+								</label>
 								<div class="agreeBorder">내용보기</div>
 							</div>
 							<div class="eventAgree">
-								<label><input type="checkbox" /> 카카오톡 수신 동의 <span
-									class="minimal">선택</span></label>
+								<label>
+									<input type="checkbox" />
+									카카오톡 수신 동의
+									<span class="minimal">선택</span>
+								</label>
 								<div class="agreeBorder">내용보기</div>
 							</div>
 						</div>
 						<div class="tooltip-wrapper">
-							<button class="btn-signup" type="submit" disabled="disabled">회원가입</button>
+							<button class="btn-signup" type="submit" disabled="disabled" id="joinBtn">회원가입</button>
 							<span class="tooltip-text">모든 필수사항을 입력해주세요</span>
 						</div>
 					</form>
@@ -128,5 +138,6 @@
 <%@ include file="/WEB-INF/views/include/footer.jsp"%>
 </body>
 </html>
-<script src ="/js/account/join.js">
+<script src="/js/account/join.js">
+	
 </script>

--- a/src/main/webapp/WEB-INF/views/account/join.jsp
+++ b/src/main/webapp/WEB-INF/views/account/join.jsp
@@ -49,7 +49,7 @@
 
 						<div class="input-row">
 							<label for="nickname">닉네임</label>
-							<input type="text" class="inputWt" id="nickname" name="memNickName" placeholder="닉네임을 입력해주세요." />
+							<input type="text" class="inputWt" id="nickname" name="memNickname" placeholder="닉네임을 입력해주세요." />
 
 							<button id="nicknameCheck" type="button">중복 확인</button>
 						</div>
@@ -109,7 +109,7 @@
 							</div>
 							<div class="eventAgree">
 								<label>
-									<input type="checkbox" />
+									<input type="checkbox" value="mail"/>
 									이벤트 등 프로모션 메일 수신 동의
 									<span class="minimal">선택</span>
 								</label>
@@ -117,7 +117,7 @@
 							</div>
 							<div class="eventAgree">
 								<label>
-									<input type="checkbox" />
+									<input type="checkbox" value="kakao"/>
 									카카오톡 수신 동의
 									<span class="minimal">선택</span>
 								</label>

--- a/src/main/webapp/WEB-INF/views/account/login.jsp
+++ b/src/main/webapp/WEB-INF/views/account/login.jsp
@@ -14,7 +14,7 @@
 		<!-- 		    <div class="tab">입시 정보</div> -->
 		<!--   		</div> -->
 		<!-- 여기부터 작성해 주시면 됩니다 -->
-		<div class="public-wrapper-main-login">
+		<div class="public-wrapper-main-login" id="public-wrapper-main-login" data-regist-message="${registMessage}">
 			<div class="login-container">
 				<div class="login-container-imgBox">
 					<img alt="" src="/images/logo.png">

--- a/src/main/webapp/WEB-INF/views/cdp/aifdbck/rsm/aiFeedbackResume.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/aifdbck/rsm/aiFeedbackResume.jsp
@@ -13,6 +13,24 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/aifdbck/rsm/aiFeedbackResumeList.do">AI 피드백</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/cdp/aifdbck/sint/aiFeedbackSelfIntro.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/aifdbck/sint/aiFeedbackSelfIntro.jsp
@@ -18,6 +18,25 @@
 		<div class="channel-sub-section-itemIn"><a href="/cdp/aifdbck/rsm/aiFeedbackResumeList.do">AI 피드백</a>	</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/aifdbck/rsm/aiFeedbackResumeList.do">AI 피드백</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<!-- 여기는 소분류(tab이라 명칭지음)인데 사용안하는곳은 주석처리 하면됩니다 -->

--- a/src/main/webapp/WEB-INF/views/cdp/imtintrvw/aiimtintrvw/aiImitationInterview.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/imtintrvw/aiimtintrvw/aiImitationInterview.jsp
@@ -22,6 +22,24 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/imtintrvw/intrvwitr/interviewIntro.do">모의면접</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/cdp/imtintrvw/intrvwitr/interviewIntro.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/imtintrvw/intrvwitr/interviewIntro.jsp
@@ -17,6 +17,23 @@
 		<div class="channel-sub-section-item"><a href="/cdp/aifdbck/rsm/aiFeedbackResumeList.do">AI 피드백</a></div>
 	</div>
 </section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/imtintrvw/intrvwitr/interviewIntro.do">모의면접</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<!-- 여기는 소분류(tab이라 명칭지음)인데 사용안하는곳은 주석처리 하면됩니다 -->

--- a/src/main/webapp/WEB-INF/views/cdp/imtintrvw/intrvwqestnlst/intrvwQuestionList.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/imtintrvw/intrvwqestnlst/intrvwQuestionList.jsp
@@ -22,6 +22,24 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/imtintrvw/intrvwitr/interviewIntro.do">모의면접</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
 		<a class="tab" href="/cdp/imtintrvw/intrvwitr/interviewIntro.do">면접의 기본</a>

--- a/src/main/webapp/WEB-INF/views/cdp/imtintrvw/intrvwqestnmn/interviewQuestionMangement.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/imtintrvw/intrvwqestnmn/interviewQuestionMangement.jsp
@@ -22,6 +22,24 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/imtintrvw/intrvwitr/interviewIntro.do">모의면접</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
 		<a class="tab" href="/cdp/imtintrvw/intrvwitr/interviewIntro.do">면접의 기본</a>

--- a/src/main/webapp/WEB-INF/views/cdp/imtintrvw/intrvwqestnmn/interviewQuestionWriting.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/imtintrvw/intrvwqestnmn/interviewQuestionWriting.jsp
@@ -22,6 +22,24 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/imtintrvw/intrvwitr/interviewIntro.do">모의면접</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
 		<a class="tab" href="/cdp/imtintrvw/intrvwitr/interviewIntro.do">면접의 기본</a>

--- a/src/main/webapp/WEB-INF/views/cdp/rsm/rsm/resumeList.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/rsm/rsm/resumeList.jsp
@@ -4,7 +4,7 @@
 
 <section class="channel">
 	<div class="channel-title">
-		<div class="channel-title-text">경력관리</div>
+		<div class="channel-title-text">경력 관리</div>
 	</div>
 	<div class="channel-sub-sections">
 		<div class="channel-sub-section-itemIn">
@@ -21,7 +21,23 @@
 		</div>
 	</div>
 </section>
-
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/rsm/rsm/resumeList.do">이력서</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
 		<a class="tab active" href="/cdp/rsm/rsm/resumeList.do">이력서</a>

--- a/src/main/webapp/WEB-INF/views/cdp/rsm/rsm/resumeWriter.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/rsm/rsm/resumeWriter.jsp
@@ -20,6 +20,23 @@
 		</div>
 	</div>
 </section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/rsm/rsm/resumeList.do">이력서</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/cdp/rsm/rsmb/resumeBoardDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/rsm/rsmb/resumeBoardDetail.jsp
@@ -21,6 +21,23 @@
 		</div>
 	</div>
 </section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/rsm/rsm/resumeList.do">이력서</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/cdp/rsm/rsmb/resumeBoardInsertView.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/rsm/rsmb/resumeBoardInsertView.jsp
@@ -25,6 +25,23 @@
 		</div>
 	</div>
 </section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/rsm/rsm/resumeList.do">이력서</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<!-- 여기는 소분류(tab이라 명칭지음)인데 사용안하는곳은 주석처리 하면됩니다 -->

--- a/src/main/webapp/WEB-INF/views/cdp/rsm/rsmb/resumeBoardList.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/rsm/rsmb/resumeBoardList.jsp
@@ -21,7 +21,23 @@
 		</div>
 	</div>
 </section>
-
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/rsm/rsm/resumeList.do">이력서</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
@@ -95,7 +111,7 @@
 					<p class="content-list__no-results">이력서 템플릿 게시판 정보가 없습니다.</p>
 				</c:if>
 			</div>
-			
+
 			<div class="action-bar">
 				<button class="action-bar__button" id="btnWrite">글작성</button>
 			</div>

--- a/src/main/webapp/WEB-INF/views/cdp/rsm/rsmb/resumeBoardUpdateView.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/rsm/rsmb/resumeBoardUpdateView.jsp
@@ -28,7 +28,23 @@
 		</div>
 	</div>
 </section>
-
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/rsm/rsm/resumeList.do">이력서</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/cdp/sint/qestnlst/questionList.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/sint/qestnlst/questionList.jsp
@@ -22,6 +22,24 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/imtintrvw/intrvwitr/interviewIntro.do">자기소개서</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
 		<a class="tab active" href="/cdp/sint/qestnlst/questionList.do">질문 리스트</a>

--- a/src/main/webapp/WEB-INF/views/cdp/sint/sintlst/selfIntroList.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/sint/sintlst/selfIntroList.jsp
@@ -22,6 +22,24 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/imtintrvw/intrvwitr/interviewIntro.do">자기소개서</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
 		<a class="tab" href="/cdp/sint/qestnlst/questionList.do">질문 리스트</a>

--- a/src/main/webapp/WEB-INF/views/cdp/sint/sintwrt/selfIntroWriting.jsp
+++ b/src/main/webapp/WEB-INF/views/cdp/sint/sintwrt/selfIntroWriting.jsp
@@ -28,6 +28,24 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cdp/rsm/rsm/resumeList.do">경력 관리</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cdp/imtintrvw/intrvwitr/interviewIntro.do">자기소개서</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
 		<a class="tab" href="/cdp/sint/qestnlst/questionList.do">질문 리스트</a>

--- a/src/main/webapp/WEB-INF/views/cnslt/aicns/aicns.jsp
+++ b/src/main/webapp/WEB-INF/views/cnslt/aicns/aicns.jsp
@@ -21,8 +21,32 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cnslt/resve/crsv/reservation.do">상담</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cnslt/aicns/aicns.do">AI 상담</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
+	
+		<div class="tab-container" id="tabs">
+			<a class="tab active" href="#">AI 상담</a>
+		</div>
+	
 		<!-- 여기부터 작성해 주시면 됩니다 -->
 		<div class="public-wrapper-main">
 			<div class="ai-wrap">

--- a/src/main/webapp/WEB-INF/views/cnslt/resve/cnsh/counselingreservehistory.jsp
+++ b/src/main/webapp/WEB-INF/views/cnslt/resve/cnsh/counselingreservehistory.jsp
@@ -19,6 +19,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cnslt/resve/crsv/reservation.do">상담</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cnslt/resve/crsv/reservation.doo">상담 예약</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/cnslt/resve/crsv/counselingreserve.jsp
+++ b/src/main/webapp/WEB-INF/views/cnslt/resve/crsv/counselingreserve.jsp
@@ -19,6 +19,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cnslt/resve/crsv/reservation.do">상담</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cnslt/resve/crsv/reservation.doo">상담 예약</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/cnslt/resve/crsv/counselingreserveDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/cnslt/resve/crsv/counselingreserveDetail.jsp
@@ -18,6 +18,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cnslt/resve/crsv/reservation.do">상담</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cnslt/resve/crsv/reservation.doo">상담 예약</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/cnslt/rvw/cnsReview.jsp
+++ b/src/main/webapp/WEB-INF/views/cnslt/rvw/cnsReview.jsp
@@ -18,10 +18,29 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cnslt/resve/crsv/reservation.do">상담</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cnslt/rvw/cnsReview.do">상담 후기</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">상담 후기</h3>
+			<a class="tab active" href="#">상담 후기</a>
 		</div>
 		<div class="public-wrapper-main">
 			<form method="get" action="${articlePage.url}" class="search-filter__form">

--- a/src/main/webapp/WEB-INF/views/cnslt/rvw/insertCnsReviewView.jsp
+++ b/src/main/webapp/WEB-INF/views/cnslt/rvw/insertCnsReviewView.jsp
@@ -19,10 +19,29 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cnslt/resve/crsv/reservation.do">상담</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cnslt/rvw/cnsReview.do">상담 후기</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">상담 후기</h3>
+			<a class="tab active" href="#">상담 후기</a>
 		</div>
 		
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/cnslt/rvw/updateCnsReviewView.jsp
+++ b/src/main/webapp/WEB-INF/views/cnslt/rvw/updateCnsReviewView.jsp
@@ -22,11 +22,31 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/cnslt/resve/crsv/reservation.do">상담</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/cnslt/rvw/cnsReview.do">상담 후기</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">상담 후기</h3>
+			<a class="tab active" href="#">상담 후기</a>
 		</div>
+		
 		<div class="public-wrapper-main">
 			<div class="feedback-form">
 				<div class="feedback-form__header">

--- a/src/main/webapp/WEB-INF/views/comm/path/pathDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/comm/path/pathDetail.jsp
@@ -14,10 +14,29 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/comm/peer/teen/teenList.do">커뮤니티</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/comm/path/pathList.do">진로/진학 게시판</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">진로/진학 게시판</h3>
+			<a class="tab active" href="/comm/path/pathList.do">진로/진학 게시판</a>
 		</div>
 
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/comm/path/pathInsert.jsp
+++ b/src/main/webapp/WEB-INF/views/comm/path/pathInsert.jsp
@@ -19,10 +19,29 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/comm/peer/teen/teenList.do">커뮤니티</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/comm/path/pathList.do">진로/진학 게시판</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">진로/진학 게시판</h3>
+			<a class="tab active" href="/comm/path/pathList.do">진로/진학 게시판</a>
 		</div>
 		<div class="public-wrapper-main">
 			<div class="titleSpace">

--- a/src/main/webapp/WEB-INF/views/comm/path/pathList.jsp
+++ b/src/main/webapp/WEB-INF/views/comm/path/pathList.jsp
@@ -15,10 +15,29 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/comm/peer/teen/teenList.do">커뮤니티</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/comm/path/pathList.do">진로/진학 게시판</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">진로/진학 게시판</h3>
+			<a class="tab active" href="/comm/path/pathList.do">진로/진학 게시판</a>
 		</div>
 		
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/comm/peer/teen/teenBoardUpdate.jsp
+++ b/src/main/webapp/WEB-INF/views/comm/peer/teen/teenBoardUpdate.jsp
@@ -24,6 +24,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/comm/peer/teen/teenList.do">커뮤니티</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/comm/peer/teen/teenList.do">또래 게시판</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/comm/peer/teen/teenDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/comm/peer/teen/teenDetail.jsp
@@ -14,6 +14,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/comm/peer/teen/teenList.do">커뮤니티</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/comm/peer/teen/teenList.do">또래 게시판</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/comm/peer/teen/teenInsert.jsp
+++ b/src/main/webapp/WEB-INF/views/comm/peer/teen/teenInsert.jsp
@@ -19,6 +19,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/comm/peer/teen/teenList.do">커뮤니티</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/comm/peer/teen/teenList.do">또래 게시판</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/comm/peer/teen/teenList.jsp
+++ b/src/main/webapp/WEB-INF/views/comm/peer/teen/teenList.jsp
@@ -20,6 +20,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/comm/peer/teen/teenList.do">커뮤니티</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/comm/peer/teen/teenList.do">또래 게시판</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<!-- 여기는 소분류(tab이라 명칭지음)인데 사용안하는곳은 주석처리 하면됩니다 -->

--- a/src/main/webapp/WEB-INF/views/comm/peer/youth/youthDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/comm/peer/youth/youthDetail.jsp
@@ -14,6 +14,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/comm/peer/teen/teenList.do">커뮤니티</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/comm/peer/teen/teenList.do">또래 게시판</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/comm/peer/youth/youthInsert.jsp
+++ b/src/main/webapp/WEB-INF/views/comm/peer/youth/youthInsert.jsp
@@ -19,6 +19,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/comm/peer/teen/teenList.do">커뮤니티</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/comm/peer/teen/teenList.do">또래 게시판</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/comm/peer/youth/youthList.jsp
+++ b/src/main/webapp/WEB-INF/views/comm/peer/youth/youthList.jsp
@@ -20,6 +20,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/comm/peer/teen/teenList.do">커뮤니티</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/comm/peer/teen/teenList.do">또래 게시판</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<!-- 여기는 소분류(tab이라 명칭지음)인데 사용안하는곳은 주석처리 하면됩니다 -->

--- a/src/main/webapp/WEB-INF/views/csc/faq/faqList.jsp
+++ b/src/main/webapp/WEB-INF/views/csc/faq/faqList.jsp
@@ -22,10 +22,29 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/csc/not/noticeList.do">고객센터</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/csc/faq/faqList.do">FAQ</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">FAQ</h3>
+			<a class="tab active" href="/csc/faq/faqList.do">FAQ</a>
 		</div>
 
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/csc/inq/inqryList.jsp
+++ b/src/main/webapp/WEB-INF/views/csc/inq/inqryList.jsp
@@ -22,10 +22,29 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/csc/not/noticeList.do">고객센터</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/csc/inq/inqryList.do">1:1문의</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">1:1 문의</h3>
+			<a class="tab active" href="/csc/inq/inqryList.do">1:1 문의</a>
 		</div>
 
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/csc/inq/insertInq.jsp
+++ b/src/main/webapp/WEB-INF/views/csc/inq/insertInq.jsp
@@ -22,10 +22,29 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/csc/not/noticeList.do">고객센터</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/csc/inq/inqryList.do">1:1문의</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">1:1 문의 작성</h3>
+			<a class="tab active" href="/csc/inq/inqryList.do">1:1 문의</a>
 		</div>
 
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/csc/not/noticeDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/csc/not/noticeDetail.jsp
@@ -22,9 +22,28 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/csc/not/noticeList.do">고객센터</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/csc/not/noticeList.do">공지사항</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
-		<h3 class="page-title-bar__title">공지사항</h3>
+		<a class="tab active" href="/csc/not/noticeList.do">공지사항</a>
 	</div>
 
 	<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/csc/not/noticeList.jsp
+++ b/src/main/webapp/WEB-INF/views/csc/not/noticeList.jsp
@@ -23,10 +23,29 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/csc/not/noticeList.do">고객센터</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/csc/not/noticeList.do">공지사항</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">공지사항</h3>
+			<a class="tab active" href="/csc/not/noticeList.do">공지사항</a>
 		</div>
 
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/empt/cte/careerTechnicalEducation.jsp
+++ b/src/main/webapp/WEB-INF/views/empt/cte/careerTechnicalEducation.jsp
@@ -210,29 +210,13 @@
 							<div class="accordion-list__content-body">
 								<div class="education-detail-section">
 									<h4>교육 상세 정보</h4>
-									<p>
-										<strong>교육명:</strong>&nbsp; ${data.jtName}
-									</p>
-									<p>
-										<strong>교육기관:</strong>&nbsp; ${data.jtSchool}
-									</p>
-									<p>
-										<strong>정원:</strong>&nbsp; ${data.jtQuota}명
-									</p>
-									<p>
-										<strong>교육 대상:</strong>&nbsp; ${data.jtTarget}
-									</p>
-									<p>
-										<strong>교육 평점:</strong>&nbsp; ${data.jtScore}점
-									</p>
-									<p>
-										<strong>훈련비:</strong>&nbsp;
-										<fmt:formatNumber value="${data.jtFee}" type="currency" currencySymbol="" groupingUsed="true" />
-										원
-									</p>
-									<p>
-										<strong>교육기관 주소:</strong>&nbsp; ${data.jtAddress}
-									</p>
+									<p><strong>교육명:</strong>&nbsp; ${data.jtName}</p>
+									<p><strong>교육기관:</strong>&nbsp; ${data.jtSchool}</p>
+									<p><strong>정원:</strong>&nbsp; ${data.jtQuota}명</p>
+									<p><strong>교육 대상:</strong>&nbsp; ${data.jtTarget}</p>
+									<p><strong>교육 평점:</strong>&nbsp; ${data.jtScore}점</p>
+									<p><strong>훈련비:</strong>&nbsp; <fmt:formatNumber value="${data.jtFee}" type="currency" currencySymbol="" groupingUsed="true" /> 원</p>
+									<p><strong>교육기관 주소:</strong>&nbsp; ${data.jtAddress}</p>
 								</div>
 
 								<div class="education-url-section">

--- a/src/main/webapp/WEB-INF/views/empt/cte/careerTechnicalEducation.jsp
+++ b/src/main/webapp/WEB-INF/views/empt/cte/careerTechnicalEducation.jsp
@@ -20,10 +20,27 @@
 		</div>
 	</div>
 </section>
+<div class="breadcrumb-container-space" data-error-message="${errorMessage}">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/empt/ema/employmentAdvertisement.do">취업 정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/empt/cte/careerTechnicalEducation.do">직업교육</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">직업교육</h3>
+			<a class="tab active" href="/empt/cte/careerTechnicalEducation.do">직업교육</a>
 		</div>
 
 		<div class="public-wrapper-main">
@@ -193,13 +210,29 @@
 							<div class="accordion-list__content-body">
 								<div class="education-detail-section">
 									<h4>교육 상세 정보</h4>
-									<p><strong>교육명:</strong>&nbsp; ${data.jtName}</p>
-									<p><strong>교육기관:</strong>&nbsp; ${data.jtSchool}</p>
-									<p><strong>정원:</strong>&nbsp; ${data.jtQuota}명</p>
-									<p><strong>교육 대상:</strong>&nbsp; ${data.jtTarget}</p>
-									<p><strong>교육 평점:</strong>&nbsp; ${data.jtScore}점</p>
-									<p><strong>훈련비:</strong>&nbsp; <fmt:formatNumber value="${data.jtFee}" type="currency" currencySymbol="" groupingUsed="true" /> 원</p>
-									<p><strong>교육기관 주소:</strong>&nbsp; ${data.jtAddress}</p>
+									<p>
+										<strong>교육명:</strong>&nbsp; ${data.jtName}
+									</p>
+									<p>
+										<strong>교육기관:</strong>&nbsp; ${data.jtSchool}
+									</p>
+									<p>
+										<strong>정원:</strong>&nbsp; ${data.jtQuota}명
+									</p>
+									<p>
+										<strong>교육 대상:</strong>&nbsp; ${data.jtTarget}
+									</p>
+									<p>
+										<strong>교육 평점:</strong>&nbsp; ${data.jtScore}점
+									</p>
+									<p>
+										<strong>훈련비:</strong>&nbsp;
+										<fmt:formatNumber value="${data.jtFee}" type="currency" currencySymbol="" groupingUsed="true" />
+										원
+									</p>
+									<p>
+										<strong>교육기관 주소:</strong>&nbsp; ${data.jtAddress}
+									</p>
 								</div>
 
 								<div class="education-url-section">

--- a/src/main/webapp/WEB-INF/views/empt/ema/employmentAdvertisement.jsp
+++ b/src/main/webapp/WEB-INF/views/empt/ema/employmentAdvertisement.jsp
@@ -1,31 +1,25 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/empt/ema/employmentAdvertisement.css">
-<section class="channel">
-	<div class="channel-title">
-		<div class="channel-title-text">취업 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-itemIn">
-			<a href="/empt/ema/employmentAdvertisement.do">채용공고</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/empt/enp/enterprisePosting.do">기업정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/empt/cte/careerTechnicalEducation.do">직업교육</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/empt/ema/employmentAdvertisement.do">취업정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/empt/ema/employmentAdvertisement.do">채용공고</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
-		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">채용 공고</h3>
-		</div>
-	
 		<div class="public-wrapper-main">
 			<form method="get" action="/empt/ema/employmentAdvertisement.do" class="search-filter__form">
 				<div class="search-filter__bar">

--- a/src/main/webapp/WEB-INF/views/empt/ema/employmentAdvertisement.jsp
+++ b/src/main/webapp/WEB-INF/views/empt/ema/employmentAdvertisement.jsp
@@ -1,6 +1,25 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/empt/ema/employmentAdvertisement.css">
+<section class="channel">
+	<div class="channel-title">
+		<div class="channel-title-text">취업 정보</div>
+	</div>
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-itemIn">
+			<a href="/empt/ema/employmentAdvertisement.do">채용공고</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/empt/enp/enterprisePosting.do">기업정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/empt/cte/careerTechnicalEducation.do">직업교육</a>
+		</div>
+	</div>
+</section>
 <div class="breadcrumb-container-space">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
@@ -10,7 +29,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/empt/ema/employmentAdvertisement.do">취업정보</a>
+				<a href="/empt/ema/employmentAdvertisement.do">취업 정보</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/empt/ema/employmentAdvertisement.do">채용공고</a>
@@ -20,6 +39,9 @@
 </div>
 <div>
 	<div class="public-wrapper">
+		<div class="tab-container" id="tabs">
+			<a class="tab active" href="/empt/ema/employmentAdvertisement.do">채용공고</a>
+		</div>
 		<div class="public-wrapper-main">
 			<form method="get" action="/empt/ema/employmentAdvertisement.do" class="search-filter__form">
 				<div class="search-filter__bar">

--- a/src/main/webapp/WEB-INF/views/empt/enp/enterprisePosting.jsp
+++ b/src/main/webapp/WEB-INF/views/empt/enp/enterprisePosting.jsp
@@ -1,6 +1,25 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/empt/enp/enterprisePosting.css">
+<section class="channel">
+	<div class="channel-title">
+		<div class="channel-title-text">취업 정보</div>
+	</div>
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-item">
+			<a href="/empt/ema/employmentAdvertisement.do">채용공고</a>
+		</div>
+		<div class="channel-sub-section-itemIn">
+			<a href="/empt/enp/enterprisePosting.do">기업정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/empt/cte/careerTechnicalEducation.do">직업교육</a>
+		</div>
+	</div>
+</section>
 <div class="breadcrumb-container-space">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
@@ -10,7 +29,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/empt/ema/employmentAdvertisement.do">취업정보</a>
+				<a href="/empt/ema/employmentAdvertisement.do">취업 정보</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/empt/enp/enterprisePosting.do">기업정보</a>
@@ -20,8 +39,10 @@
 </div>
 <div>
 	<div class="public-wrapper">
-	
-		
+		<div class="tab-container" id="tabs">
+			<a class="tab active" href="/empt/enp/enterprisePosting.do">기업정보</a>
+		</div>
+
 		<div class="public-wrapper-main">
 			<form method="get" action="/empt/enp/enterprisePosting.do" class="search-filter__form">
 				<div class="search-filter__bar">
@@ -161,7 +182,9 @@
 									<h4>현재 채용 여부</h4>
 									<c:choose>
 										<c:when test="${company.cpHiringStatus eq 'Y'}">
-											<p><a href="/empt/ema/employmentAdvertisement.do?keyword=${fn:escapeXml(company.cpName)}" class="hiring-link">채용 중 (채용공고 바로가기)</a></p>
+											<p>
+												<a href="/empt/ema/employmentAdvertisement.do?keyword=${fn:escapeXml(company.cpName)}" class="hiring-link">채용 중 (채용공고 바로가기)</a>
+											</p>
 										</c:when>
 										<c:otherwise>
 											<p>채용 없음</p>
@@ -189,7 +212,7 @@
 															<span class="review-rating-text">${interviewReview.irRating} / 5.0</span>
 														</div>
 													</div>
-													
+
 													<p class="review-date">
 														<fmt:formatDate value="${interviewReview.irCreatedAt}" pattern="yyyy. MM. dd" />
 													</p>

--- a/src/main/webapp/WEB-INF/views/empt/enp/enterprisePosting.jsp
+++ b/src/main/webapp/WEB-INF/views/empt/enp/enterprisePosting.jsp
@@ -1,30 +1,26 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/empt/enp/enterprisePosting.css">
-<section class="channel">
-	<div class="channel-title">
-		<div class="channel-title-text">취업 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-item">
-			<a href="/empt/ema/employmentAdvertisement.do">채용공고</a>
-		</div>
-		<div class="channel-sub-section-itemIn">
-			<a href="/empt/enp/enterprisePosting.do">기업정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/empt/cte/careerTechnicalEducation.do">직업교육</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/empt/ema/employmentAdvertisement.do">취업정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/empt/enp/enterprisePosting.do">기업정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
-		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">기업 정보</h3>
-		</div>
+	
 		
 		<div class="public-wrapper-main">
 			<form method="get" action="/empt/enp/enterprisePosting.do" class="search-filter__form">

--- a/src/main/webapp/WEB-INF/views/empt/ivfb/insertInterViewFeedbackView.jsp
+++ b/src/main/webapp/WEB-INF/views/empt/ivfb/insertInterViewFeedbackView.jsp
@@ -1,6 +1,26 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/common/insertInterviewFeedbackView.css">
+<section class="channel">
+	<div class="channel-title">
+		<div class="channel-title-text">취업 정보</div>
+	</div>
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-item">
+			<a href="/empt/ema/employmentAdvertisement.do">채용공고</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/empt/enp/enterprisePosting.do">기업정보</a>
+		</div>
+		<div class="channel-sub-section-itemIn">
+			<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/empt/cte/careerTechnicalEducation.do">직업교육</a>
+		</div>
+	</div>
+</section>
+
 <!-- 스타일 여기 적어주시면 가능 -->
 <div class="breadcrumb-container-space">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
@@ -11,7 +31,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/empt/ema/employmentAdvertisement.do">취업정보</a>
+				<a href="/empt/ema/employmentAdvertisement.do">취업 정보</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
@@ -19,10 +39,11 @@
 		</ol>
 	</nav>
 </div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">면접 후기</h3>
+			<a class="tab active" href="/empt/ivfb/interViewFeedback.do">면접후기</a>
 		</div>
 		<div class="public-wrapper-main">
 			<div class="feedback-form">

--- a/src/main/webapp/WEB-INF/views/empt/ivfb/insertInterViewFeedbackView.jsp
+++ b/src/main/webapp/WEB-INF/views/empt/ivfb/insertInterViewFeedbackView.jsp
@@ -2,29 +2,23 @@
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/common/insertInterviewFeedbackView.css">
 <!-- 스타일 여기 적어주시면 가능 -->
-<section class="channel">
-	<!-- 	여기가 네비게이션 역할을 합니다.  -->
-	<div class="channel-title">
-		<!-- 대분류 -->
-		<div class="channel-title-text">취업 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<!-- 중분류 -->
-		<div class="channel-sub-section-item">
-			<a href="/empt/ema/employmentAdvertisement.do">채용공고</a>
-		</div>
-		<!-- 중분류 -->
-		<div class="channel-sub-section-item">
-			<a href="/empt/enp/enterprisePosting.do">기업정보</a>
-		</div>
-		<div class="channel-sub-section-itemIn">
-			<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/empt/cte/careerTechnicalEducation.do">직업교육</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/empt/ema/employmentAdvertisement.do">취업정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/empt/ivfb/interviewFeedback.jsp
+++ b/src/main/webapp/WEB-INF/views/empt/ivfb/interviewFeedback.jsp
@@ -1,6 +1,25 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/empt/ivfb/interviewFeedback.css">
+<section class="channel">
+	<div class="channel-title">
+		<div class="channel-title-text">취업 정보</div>
+	</div>
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-item">
+			<a href="/empt/ema/employmentAdvertisement.do">채용공고</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/empt/enp/enterprisePosting.do">기업정보</a>
+		</div>
+		<div class="channel-sub-section-itemIn">
+			<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/empt/cte/careerTechnicalEducation.do">직업교육</a>
+		</div>
+	</div>
+</section>
 <div class="breadcrumb-container-space" data-error-message="${errorMessage}">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
@@ -10,7 +29,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/empt/ema/employmentAdvertisement.do">취업정보</a>
+				<a href="/empt/ema/employmentAdvertisement.do">취업 정보</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
@@ -20,6 +39,9 @@
 </div>
 <div>
 	<div class="public-wrapper">
+		<div class="tab-container" id="tabs">
+			<a class="tab active" href="/empt/ivfb/interViewFeedback.do">면접후기</a>
+		</div>
 		<div class="public-wrapper-main">
 			<form method="get" action="${articlePage.url}" class="search-filter__form">
 				<div class="search-filter__bar">
@@ -141,12 +163,8 @@
 								</div>
 								<c:if test="${pageContext.request.userPrincipal.principal == content.memId}">
 									<div class="card-actions">
-										<button type="button" class="card-actions__button card-actions__button--edit" data-mem-id="${content.memId}" data-ir-id="${content.irId}">
-										수정
-										</button>
-										<button type="button" class="card-actions__button card-actions__button--delete" data-ir-id="${content.irId}">
-										삭제
-										</button>
+										<button type="button" class="card-actions__button card-actions__button--edit" data-mem-id="${content.memId}" data-ir-id="${content.irId}">수정</button>
+										<button type="button" class="card-actions__button card-actions__button--delete" data-ir-id="${content.irId}">삭제</button>
 									</div>
 								</c:if>
 							</div>
@@ -157,11 +175,11 @@
 					<p class="content-list__no-results">면접 후기가 없습니다.</p>
 				</c:if>
 			</div>
-			
+
 			<div class="page-actions">
 				<button id="btnWrite" class="page-actions__button">면접 후기 공유하기</button>
 			</div>
-			
+
 			<div class="pagination">
 				<c:url var="prevUrl" value="${articlePage.url}">
 					<c:param name="currentPage" value="${articlePage.startPage - 5}" />

--- a/src/main/webapp/WEB-INF/views/empt/ivfb/interviewFeedback.jsp
+++ b/src/main/webapp/WEB-INF/views/empt/ivfb/interviewFeedback.jsp
@@ -1,31 +1,25 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/empt/ivfb/interviewFeedback.css">
-<section class="channel" data-error-message="${errorMessage}">
-	<div class="channel-title">
-		<div class="channel-title-text">취업 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-item">
-			<a href="/empt/ema/employmentAdvertisement.do">채용공고</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/empt/enp/enterprisePosting.do">기업정보</a>
-		</div>
-		<div class="channel-sub-section-itemIn">
-			<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/empt/cte/careerTechnicalEducation.do">직업교육</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space" data-error-message="${errorMessage}">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/empt/ema/employmentAdvertisement.do">취업정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
-		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">기업 면접 후기</h3>
-		</div>
-
 		<div class="public-wrapper-main">
 			<form method="get" action="${articlePage.url}" class="search-filter__form">
 				<div class="search-filter__bar">

--- a/src/main/webapp/WEB-INF/views/empt/ivfb/updateInterViewFeedbackView.jsp
+++ b/src/main/webapp/WEB-INF/views/empt/ivfb/updateInterViewFeedbackView.jsp
@@ -25,10 +25,27 @@
 		</div>
 	</div>
 </section>
+<div class="breadcrumb-container-space" data-error-message="${errorMessage}">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/empt/ema/employmentAdvertisement.do">취업 정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/empt/ivfb/interViewFeedback.do">면접후기</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">면접 후기</h3>
+			<a class="tab active" href="/empt/ivfb/interViewFeedback.do">면접후기</a>
 		</div>
 		<div class="public-wrapper-main">
 			<div class="feedback-form">

--- a/src/main/webapp/WEB-INF/views/ertds/hgschl/HighSchoolDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/hgschl/HighSchoolDetail.jsp
@@ -2,6 +2,25 @@
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/common/selectDetailPage.css">
 <link rel="stylesheet" href="/css/ertds/hgschl/HighSchoolDetail.css">
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진학 정보</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-item">
+			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+		</div>
+		<div class="channel-sub-section-itemIn">
+			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
+		</div>
+	</div>
+</section>
 <div class="breadcrumb-container-space">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
@@ -11,7 +30,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학 정보</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
@@ -21,6 +40,9 @@
 </div>
 <div>
 	<div class="public-wrapper">
+		<div class="tab-container" id="tabs">
+			<a class="tab active" href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+		</div>
 		<div class="public-wrapper-main">
 			<span class="detail-header__meta-item detail-header__meta-item--source">[ 출처 : 나이스 교육정보 개방 포털(NEIS) ]</span>
 			<div class="detail-page" id="highSchoolDetailContainer" data-hs-name="${highSchool.hsName}" data-hs-addr="${highSchool.hsAddr}" data-hs-tel="${highSchool.hsTel}" data-hs-lat="${empty highSchool.hsLat ? 0 : highSchool.hsLat}" data-hs-lot="${empty highSchool.hsLot ? 0 : highSchool.hsLot}">

--- a/src/main/webapp/WEB-INF/views/ertds/hgschl/HighSchoolDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/hgschl/HighSchoolDetail.jsp
@@ -2,27 +2,25 @@
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/common/selectDetailPage.css">
 <link rel="stylesheet" href="/css/ertds/hgschl/HighSchoolDetail.css">
-<section class="channel">
-	<div class="channel-title">
-		<div class="channel-title-text">진학 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-item">
-			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
-		</div>
-		<div class="channel-sub-section-itemIn">
-			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
-		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">고등학교 정보</h3>
-		</div>
 		<div class="public-wrapper-main">
 			<span class="detail-header__meta-item detail-header__meta-item--source">[ 출처 : 나이스 교육정보 개방 포털(NEIS) ]</span>
 			<div class="detail-page" id="highSchoolDetailContainer" data-hs-name="${highSchool.hsName}" data-hs-addr="${highSchool.hsAddr}" data-hs-tel="${highSchool.hsTel}" data-hs-lat="${empty highSchool.hsLat ? 0 : highSchool.hsLat}" data-hs-lot="${empty highSchool.hsLot ? 0 : highSchool.hsLot}">

--- a/src/main/webapp/WEB-INF/views/ertds/hgschl/HighSchoolList.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/hgschl/HighSchoolList.jsp
@@ -1,179 +1,200 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ include file="/WEB-INF/views/include/header.jsp"%>
-<link rel="stylesheet" href="/css/ertds/hgschl/HighSchoolList.css">
-<section class="channel">
-	<div class="channel-title">
-		<div class="channel-title-text">진학 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-item">
-			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+	<%@ include file="/WEB-INF/views/include/header.jsp" %>
+		<link rel="stylesheet" href="/css/ertds/hgschl/HighSchoolList.css">
+		<div class="breadcrumb-container-space">
+			<nav class="breadcrumb-container" aria-label="breadcrumb">
+				<ol class="breadcrumb">
+					<li class="breadcrumb-item">
+						<a href="/">
+							<i class="fa-solid fa-house"></i> 홈
+						</a>
+					</li>
+					<li class="breadcrumb-item">
+						<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+					</li>
+					<li class="breadcrumb-item active">
+						<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+					</li>
+				</ol>
+			</nav>
 		</div>
-		<div class="channel-sub-section-itemIn">
-			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
-		</div>
-	</div>
-</section>
-<div>
-	<div class="public-wrapper">
-		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">고등학교 정보</h3>
-		</div>
-		<div class="public-wrapper-main">
-			<form method="get" action="/ertds/hgschl/selectHgschList.do" class="search-filter__form">
-				<div class="search-filter__bar">
-					<div class="search-filter__input-wrapper">
-						<input class="search-filter__input" type="search" name="keyword" placeholder="고등학교명으로 검색" value="${checkedFilters.keyword}">
-						<button class="search-filter__button" type="submit">
-							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
-								<path fill-rule="evenodd" d="M10.5 3.75a6.75 6.75 0 1 0 0 13.5 6.75 6.75 0 0 0 0-13.5ZM2.25 10.5a8.25 8.25 0 1 1 14.59 5.28l4.69 4.69a.75.75 0 1 1-1.06 1.06l-4.69-4.69A8.25 8.25 0 0 1 2.25 10.5Z" clip-rule="evenodd" /></svg>
-						</button>
-					</div>
-				</div>
-				<div class="search-filter__accordion">
-					<button type="button" class="search-filter__accordion-header">
-						<span>상세검색</span>
-						<span class="search-filter__accordion-arrow">▲</span>
-					</button>
-					<div class="search-filter__accordion-panel">
-						<div class="search-filter__accordion-content">
-							<div class="search-filter__group">
-								<label class="search-filter__group-title">지역</label>
-								<div class="search-filter__options">
-									<c:forEach var="region" items="${regionList}">
-										<label class="search-filter__option">
-											<input type="checkbox" name="regionFilter" value="${region.ccId}" <c:forEach var="checkedRegion" items="${paramValues.regionFilter}">
-                                        <c:if test="${checkedRegion eq region.ccId}">checked</c:if>
-                                    </c:forEach>>
+		<div>
+			<div class="public-wrapper">
+
+				<div class="public-wrapper-main">
+					<form method="get" action="/ertds/hgschl/selectHgschList.do" class="search-filter__form">
+						<div class="search-filter__bar">
+							<div class="search-filter__input-wrapper">
+								<input class="search-filter__input" type="search" name="keyword"
+									placeholder="고등학교명으로 검색" value="${checkedFilters.keyword}">
+								<button class="search-filter__button" type="submit">
+									<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"
+										width="20" height="20">
+										<path fill-rule="evenodd"
+											d="M10.5 3.75a6.75 6.75 0 1 0 0 13.5 6.75 6.75 0 0 0 0-13.5ZM2.25 10.5a8.25 8.25 0 1 1 14.59 5.28l4.69 4.69a.75.75 0 1 1-1.06 1.06l-4.69-4.69A8.25 8.25 0 0 1 2.25 10.5Z"
+											clip-rule="evenodd" />
+									</svg>
+								</button>
+							</div>
+						</div>
+						<div class="search-filter__accordion">
+							<button type="button" class="search-filter__accordion-header">
+								<span>상세검색</span>
+								<span class="search-filter__accordion-arrow">▲</span>
+							</button>
+							<div class="search-filter__accordion-panel">
+								<div class="search-filter__accordion-content">
+									<div class="search-filter__group">
+										<label class="search-filter__group-title">지역</label>
+										<div class="search-filter__options">
+											<c:forEach var="region" items="${regionList}">
+												<label class="search-filter__option">
+													<input type="checkbox" name="regionFilter" value="${region.ccId}"
+														<c:forEach var="checkedRegion"
+														items="${paramValues.regionFilter}">
+													<c:if test="${checkedRegion eq region.ccId}">checked</c:if>
+											</c:forEach>>
 											<span>${region.ccName}</span>
-										</label>
-									</c:forEach>
-								</div>
-							</div>
-							<div class="search-filter__group">
-								<label class="search-filter__group-title">학교 유형</label>
-								<div class="search-filter__options">
-									<c:forEach var="sType" items="${schoolTypeList}">
-										<label class="search-filter__option">
-											<input type="checkbox" name="schoolType" value="${sType.ccId}" <c:forEach var="checkedSType" items="${paramValues.schoolType}">
-                                        <c:if test="${checkedSType eq sType.ccId}">checked</c:if>
-                                    </c:forEach>>
+											</label>
+											</c:forEach>
+										</div>
+									</div>
+									<div class="search-filter__group">
+										<label class="search-filter__group-title">학교 유형</label>
+										<div class="search-filter__options">
+											<c:forEach var="sType" items="${schoolTypeList}">
+												<label class="search-filter__option">
+													<input type="checkbox" name="schoolType" value="${sType.ccId}"
+														<c:forEach var="checkedSType" items="${paramValues.schoolType}">
+													<c:if test="${checkedSType eq sType.ccId}">checked</c:if>
+											</c:forEach>>
 											<span>${sType.ccName}</span>
-										</label>
-									</c:forEach>
-								</div>
-							</div>
-							<div class="search-filter__group">
-								<label class="search-filter__group-title">공학 여부</label>
-								<div class="search-filter__options">
-									<c:forEach var="cType" items="${coedTypeList}">
-										<label class="search-filter__option">
-											<input type="checkbox" name="coedTypeFilter" value="${cType.ccId}" <c:forEach var="checkedCType" items="${paramValues.coedTypeFilter}">
-                                        <c:if test="${checkedCType eq cType.ccId}">checked</c:if>
-                                    </c:forEach>>
+											</label>
+											</c:forEach>
+										</div>
+									</div>
+									<div class="search-filter__group">
+										<label class="search-filter__group-title">공학 여부</label>
+										<div class="search-filter__options">
+											<c:forEach var="cType" items="${coedTypeList}">
+												<label class="search-filter__option">
+													<input type="checkbox" name="coedTypeFilter" value="${cType.ccId}"
+														<c:forEach var="checkedCType"
+														items="${paramValues.coedTypeFilter}">
+													<c:if test="${checkedCType eq cType.ccId}">checked</c:if>
+											</c:forEach>>
 											<span>${cType.ccName}</span>
-										</label>
-									</c:forEach>
+											</label>
+											</c:forEach>
+										</div>
+									</div>
+									<div class="search-filter__group">
+										<div class="search-filter__group-header">
+											<label class="search-filter__group-title">선택된 필터</label>
+											<button type="button" class="search-filter__reset-button">초기화</button>
+										</div>
+										<div class="search-filter__selected-tags"></div>
+									</div>
+									<button type="submit" class="search-filter__submit-button">검색</button>
 								</div>
 							</div>
-							<div class="search-filter__group">
-								<div class="search-filter__group-header">
-									<label class="search-filter__group-title">선택된 필터</label>
-									<button type="button" class="search-filter__reset-button">초기화</button>
+						</div>
+					</form>
+					<span class="list-header__meta-item list-header__meta-item--source">[ 출처 : 나이스 교육정보 개방
+						포털(NEIS)]</span>
+					<div class="content-list">
+						<div class="content-list__header">
+							<span class="content-list__col content-list__col--school-name">학교명</span>
+							<span class="content-list__col content-list__col--coed">공학여부</span>
+							<span class="content-list__col content-list__col--type">학교유형</span>
+							<span class="content-list__col content-list__col--found">설립유형</span>
+							<span class="content-list__col content-list__col--region">지역</span>
+						</div>
+						<c:forEach var="school" items="${articlePage.content}">
+							<div class="content-list__item" data-hs-id="${school.hsId}">
+								<div class="content-list__col content-list__col--school-name" data-label="학교명">
+									<h3 class="content-list__title">${school.hsName}</h3>
 								</div>
-								<div class="search-filter__selected-tags"></div>
+								<div class="content-list__col content-list__col--coed" data-label="공학여부">
+									${school.hsCoeduType}</div>
+								<div class="content-list__col content-list__col--type" data-label="학교유형">
+									${school.hsTypeName}</div>
+								<div class="content-list__col content-list__col--found" data-label="설립유형">
+									${school.hsFoundType}</div>
+								<div class="content-list__col content-list__col--region" data-label="지역">
+									${school.hsRegion}</div>
 							</div>
-							<button type="submit" class="search-filter__submit-button">검색</button>
-						</div>
-					</div>
-				</div>
-			</form>
-			<span class="list-header__meta-item list-header__meta-item--source">[ 출처 : 나이스 교육정보 개방 포털(NEIS) ]</span>
-			<div class="content-list">
-				<div class="content-list__header">
-					<span class="content-list__col content-list__col--school-name">학교명</span>
-					<span class="content-list__col content-list__col--coed">공학여부</span>
-					<span class="content-list__col content-list__col--type">학교유형</span>
-					<span class="content-list__col content-list__col--found">설립유형</span>
-					<span class="content-list__col content-list__col--region">지역</span>
-				</div>
-				<c:forEach var="school" items="${articlePage.content}">
-					<div class="content-list__item" data-hs-id="${school.hsId}">
-						<div class="content-list__col content-list__col--school-name" data-label="학교명">
-							<h3 class="content-list__title">${school.hsName}</h3>
-						</div>
-						<div class="content-list__col content-list__col--coed" data-label="공학여부">${school.hsCoeduType}</div>
-						<div class="content-list__col content-list__col--type" data-label="학교유형">${school.hsTypeName}</div>
-						<div class="content-list__col content-list__col--found" data-label="설립유형">${school.hsFoundType}</div>
-						<div class="content-list__col content-list__col--region" data-label="지역">${school.hsRegion}</div>
-					</div>
-				</c:forEach>
-				<c:if test="${articlePage.total == 0}">
-					<p class="content-list__no-results">검색 결과가 없습니다.</p>
-				</c:if>
-			</div>
-
-			<div class="pagination">
-				<c:url var="prevUrl" value="${articlePage.url}">
-					<c:param name="currentPage" value="${articlePage.startPage - 5}" />
-					<c:if test="${not empty param.keyword}">
-						<c:param name="keyword" value="${param.keyword}" />
-					</c:if>
-					<c:forEach var="regionValue" items="${paramValues.regionFilter}">
-						<c:param name="regionFilter" value="${regionValue}" />
-					</c:forEach>
-					<c:forEach var="schoolTypeValue" items="${paramValues.schoolType}">
-						<c:param name="schoolType" value="${schoolTypeValue}" />
-					</c:forEach>
-					<c:forEach var="coedTypeValue" items="${paramValues.coedTypeFilter}">
-						<c:param name="coedTypeFilter" value="${coedTypeValue}" />
-					</c:forEach>
-				</c:url>
-				<a href="${prevUrl}" class="pagination__link ${articlePage.startPage < 6 ? 'pagination__link--disabled' : ''}"> ← Previous </a>
-
-				<c:forEach var="pNo" begin="${articlePage.startPage}" end="${articlePage.endPage}">
-					<c:url var="pageUrl" value="${articlePage.url}">
-						<c:param name="currentPage" value="${pNo}" />
-						<c:if test="${not empty param.keyword}">
-							<c:param name="keyword" value="${param.keyword}" />
+						</c:forEach>
+						<c:if test="${articlePage.total == 0}">
+							<p class="content-list__no-results">검색 결과가 없습니다.</p>
 						</c:if>
-						<c:forEach var="regionValue" items="${paramValues.regionFilter}">
-							<c:param name="regionFilter" value="${regionValue}" />
-						</c:forEach>
-						<c:forEach var="schoolTypeValue" items="${paramValues.schoolType}">
-							<c:param name="schoolType" value="${schoolTypeValue}" />
-						</c:forEach>
-						<c:forEach var="coedTypeValue" items="${paramValues.coedTypeFilter}">
-							<c:param name="coedTypeFilter" value="${coedTypeValue}" />
-						</c:forEach>
-					</c:url>
-					<a href="${pageUrl}" class="pagination__link ${pNo == articlePage.currentPage ? 'pagination__link--active' : ''}"> ${pNo} </a>
-				</c:forEach>
+					</div>
 
-				<c:url var="nextUrl" value="${articlePage.url}">
-					<c:param name="currentPage" value="${articlePage.startPage + 5}" />
-					<c:if test="${not empty param.keyword}">
-						<c:param name="keyword" value="${param.keyword}" />
-					</c:if>
-					<c:forEach var="regionValue" items="${paramValues.regionFilter}">
-						<c:param name="regionFilter" value="${regionValue}" />
-					</c:forEach>
-					<c:forEach var="schoolTypeValue" items="${paramValues.schoolType}">
-						<c:param name="schoolType" value="${schoolTypeValue}" />
-					</c:forEach>
-					<c:forEach var="coedTypeValue" items="${paramValues.coedTypeFilter}">
-						<c:param name="coedTypeFilter" value="${coedTypeValue}" />
-					</c:forEach>
-				</c:url>
-				<a href="${nextUrl}" class="pagination__link ${articlePage.endPage >= articlePage.totalPages ? 'pagination__link--disabled' : ''}"> Next → </a>
+					<div class="pagination">
+						<c:url var="prevUrl" value="${articlePage.url}">
+							<c:param name="currentPage" value="${articlePage.startPage - 5}" />
+							<c:if test="${not empty param.keyword}">
+								<c:param name="keyword" value="${param.keyword}" />
+							</c:if>
+							<c:forEach var="regionValue" items="${paramValues.regionFilter}">
+								<c:param name="regionFilter" value="${regionValue}" />
+							</c:forEach>
+							<c:forEach var="schoolTypeValue" items="${paramValues.schoolType}">
+								<c:param name="schoolType" value="${schoolTypeValue}" />
+							</c:forEach>
+							<c:forEach var="coedTypeValue" items="${paramValues.coedTypeFilter}">
+								<c:param name="coedTypeFilter" value="${coedTypeValue}" />
+							</c:forEach>
+						</c:url>
+						<a href="${prevUrl}"
+							class="pagination__link ${articlePage.startPage < 6 ? 'pagination__link--disabled' : ''}"> ←
+							Previous </a>
+
+						<c:forEach var="pNo" begin="${articlePage.startPage}" end="${articlePage.endPage}">
+							<c:url var="pageUrl" value="${articlePage.url}">
+								<c:param name="currentPage" value="${pNo}" />
+								<c:if test="${not empty param.keyword}">
+									<c:param name="keyword" value="${param.keyword}" />
+								</c:if>
+								<c:forEach var="regionValue" items="${paramValues.regionFilter}">
+									<c:param name="regionFilter" value="${regionValue}" />
+								</c:forEach>
+								<c:forEach var="schoolTypeValue" items="${paramValues.schoolType}">
+									<c:param name="schoolType" value="${schoolTypeValue}" />
+								</c:forEach>
+								<c:forEach var="coedTypeValue" items="${paramValues.coedTypeFilter}">
+									<c:param name="coedTypeFilter" value="${coedTypeValue}" />
+								</c:forEach>
+							</c:url>
+							<a href="${pageUrl}"
+								class="pagination__link ${pNo == articlePage.currentPage ? 'pagination__link--active' : ''}">
+								${pNo} </a>
+						</c:forEach>
+
+						<c:url var="nextUrl" value="${articlePage.url}">
+							<c:param name="currentPage" value="${articlePage.startPage + 5}" />
+							<c:if test="${not empty param.keyword}">
+								<c:param name="keyword" value="${param.keyword}" />
+							</c:if>
+							<c:forEach var="regionValue" items="${paramValues.regionFilter}">
+								<c:param name="regionFilter" value="${regionValue}" />
+							</c:forEach>
+							<c:forEach var="schoolTypeValue" items="${paramValues.schoolType}">
+								<c:param name="schoolType" value="${schoolTypeValue}" />
+							</c:forEach>
+							<c:forEach var="coedTypeValue" items="${paramValues.coedTypeFilter}">
+								<c:param name="coedTypeFilter" value="${coedTypeValue}" />
+							</c:forEach>
+						</c:url>
+						<a href="${nextUrl}"
+							class="pagination__link ${articlePage.endPage >= articlePage.totalPages ? 'pagination__link--disabled' : ''}">
+							Next → </a>
+					</div>
+				</div>
 			</div>
 		</div>
-	</div>
-</div>
-<%@ include file="/WEB-INF/views/include/footer.jsp"%>
-</body>
-</html>
-<script src="/js/ertds/hgschl/HighSchoolList.js"></script>
+		<%@ include file="/WEB-INF/views/include/footer.jsp" %>
+			</body>
+
+			</html>
+			<script src="/js/ertds/hgschl/HighSchoolList.js"></script>

--- a/src/main/webapp/WEB-INF/views/ertds/hgschl/HighSchoolList.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/hgschl/HighSchoolList.jsp
@@ -1,200 +1,203 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-	<%@ include file="/WEB-INF/views/include/header.jsp" %>
-		<link rel="stylesheet" href="/css/ertds/hgschl/HighSchoolList.css">
-		<div class="breadcrumb-container-space">
-			<nav class="breadcrumb-container" aria-label="breadcrumb">
-				<ol class="breadcrumb">
-					<li class="breadcrumb-item">
-						<a href="/">
-							<i class="fa-solid fa-house"></i> 홈
-						</a>
-					</li>
-					<li class="breadcrumb-item">
-						<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
-					</li>
-					<li class="breadcrumb-item active">
-						<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
-					</li>
-				</ol>
-			</nav>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ include file="/WEB-INF/views/include/header.jsp"%>
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진학 정보</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-item">
+			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
 		</div>
-		<div>
-			<div class="public-wrapper">
-
-				<div class="public-wrapper-main">
-					<form method="get" action="/ertds/hgschl/selectHgschList.do" class="search-filter__form">
-						<div class="search-filter__bar">
-							<div class="search-filter__input-wrapper">
-								<input class="search-filter__input" type="search" name="keyword"
-									placeholder="고등학교명으로 검색" value="${checkedFilters.keyword}">
-								<button class="search-filter__button" type="submit">
-									<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"
-										width="20" height="20">
-										<path fill-rule="evenodd"
-											d="M10.5 3.75a6.75 6.75 0 1 0 0 13.5 6.75 6.75 0 0 0 0-13.5ZM2.25 10.5a8.25 8.25 0 1 1 14.59 5.28l4.69 4.69a.75.75 0 1 1-1.06 1.06l-4.69-4.69A8.25 8.25 0 0 1 2.25 10.5Z"
-											clip-rule="evenodd" />
+		<div class="channel-sub-section-itemIn">
+			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
+		</div>
+	</div>
+</section>
+<link rel="stylesheet" href="/css/ertds/hgschl/HighSchoolList.css">
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학 정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+<div>
+	<div class="public-wrapper">
+		<div class="tab-container" id="tabs">
+			<a class="tab active" href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+		</div>
+		<div class="public-wrapper-main">
+			<form method="get" action="/ertds/hgschl/selectHgschList.do" class="search-filter__form">
+				<div class="search-filter__bar">
+					<div class="search-filter__input-wrapper">
+						<input class="search-filter__input" type="search" name="keyword" placeholder="고등학교명으로 검색" value="${checkedFilters.keyword}">
+						<button class="search-filter__button" type="submit">
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
+										<path fill-rule="evenodd" d="M10.5 3.75a6.75 6.75 0 1 0 0 13.5 6.75 6.75 0 0 0 0-13.5ZM2.25 10.5a8.25 8.25 0 1 1 14.59 5.28l4.69 4.69a.75.75 0 1 1-1.06 1.06l-4.69-4.69A8.25 8.25 0 0 1 2.25 10.5Z" clip-rule="evenodd" />
 									</svg>
-								</button>
-							</div>
-						</div>
-						<div class="search-filter__accordion">
-							<button type="button" class="search-filter__accordion-header">
-								<span>상세검색</span>
-								<span class="search-filter__accordion-arrow">▲</span>
-							</button>
-							<div class="search-filter__accordion-panel">
-								<div class="search-filter__accordion-content">
-									<div class="search-filter__group">
-										<label class="search-filter__group-title">지역</label>
-										<div class="search-filter__options">
-											<c:forEach var="region" items="${regionList}">
-												<label class="search-filter__option">
-													<input type="checkbox" name="regionFilter" value="${region.ccId}"
-														<c:forEach var="checkedRegion"
+						</button>
+					</div>
+				</div>
+				<div class="search-filter__accordion">
+					<button type="button" class="search-filter__accordion-header">
+						<span>상세검색</span>
+						<span class="search-filter__accordion-arrow">▲</span>
+					</button>
+					<div class="search-filter__accordion-panel">
+						<div class="search-filter__accordion-content">
+							<div class="search-filter__group">
+								<label class="search-filter__group-title">지역</label>
+								<div class="search-filter__options">
+									<c:forEach var="region" items="${regionList}">
+										<label class="search-filter__option">
+											<input type="checkbox" name="regionFilter" value="${region.ccId}" <c:forEach var="checkedRegion"
 														items="${paramValues.regionFilter}">
 													<c:if test="${checkedRegion eq region.ccId}">checked</c:if>
 											</c:forEach>>
 											<span>${region.ccName}</span>
-											</label>
-											</c:forEach>
-										</div>
-									</div>
-									<div class="search-filter__group">
-										<label class="search-filter__group-title">학교 유형</label>
-										<div class="search-filter__options">
-											<c:forEach var="sType" items="${schoolTypeList}">
-												<label class="search-filter__option">
-													<input type="checkbox" name="schoolType" value="${sType.ccId}"
-														<c:forEach var="checkedSType" items="${paramValues.schoolType}">
+										</label>
+									</c:forEach>
+								</div>
+							</div>
+							<div class="search-filter__group">
+								<label class="search-filter__group-title">학교 유형</label>
+								<div class="search-filter__options">
+									<c:forEach var="sType" items="${schoolTypeList}">
+										<label class="search-filter__option">
+											<input type="checkbox" name="schoolType" value="${sType.ccId}" <c:forEach var="checkedSType" items="${paramValues.schoolType}">
 													<c:if test="${checkedSType eq sType.ccId}">checked</c:if>
 											</c:forEach>>
 											<span>${sType.ccName}</span>
-											</label>
-											</c:forEach>
-										</div>
-									</div>
-									<div class="search-filter__group">
-										<label class="search-filter__group-title">공학 여부</label>
-										<div class="search-filter__options">
-											<c:forEach var="cType" items="${coedTypeList}">
-												<label class="search-filter__option">
-													<input type="checkbox" name="coedTypeFilter" value="${cType.ccId}"
-														<c:forEach var="checkedCType"
+										</label>
+									</c:forEach>
+								</div>
+							</div>
+							<div class="search-filter__group">
+								<label class="search-filter__group-title">공학 여부</label>
+								<div class="search-filter__options">
+									<c:forEach var="cType" items="${coedTypeList}">
+										<label class="search-filter__option">
+											<input type="checkbox" name="coedTypeFilter" value="${cType.ccId}" <c:forEach var="checkedCType"
 														items="${paramValues.coedTypeFilter}">
 													<c:if test="${checkedCType eq cType.ccId}">checked</c:if>
 											</c:forEach>>
 											<span>${cType.ccName}</span>
-											</label>
-											</c:forEach>
-										</div>
-									</div>
-									<div class="search-filter__group">
-										<div class="search-filter__group-header">
-											<label class="search-filter__group-title">선택된 필터</label>
-											<button type="button" class="search-filter__reset-button">초기화</button>
-										</div>
-										<div class="search-filter__selected-tags"></div>
-									</div>
-									<button type="submit" class="search-filter__submit-button">검색</button>
+										</label>
+									</c:forEach>
 								</div>
 							</div>
-						</div>
-					</form>
-					<span class="list-header__meta-item list-header__meta-item--source">[ 출처 : 나이스 교육정보 개방
-						포털(NEIS)]</span>
-					<div class="content-list">
-						<div class="content-list__header">
-							<span class="content-list__col content-list__col--school-name">학교명</span>
-							<span class="content-list__col content-list__col--coed">공학여부</span>
-							<span class="content-list__col content-list__col--type">학교유형</span>
-							<span class="content-list__col content-list__col--found">설립유형</span>
-							<span class="content-list__col content-list__col--region">지역</span>
-						</div>
-						<c:forEach var="school" items="${articlePage.content}">
-							<div class="content-list__item" data-hs-id="${school.hsId}">
-								<div class="content-list__col content-list__col--school-name" data-label="학교명">
-									<h3 class="content-list__title">${school.hsName}</h3>
+							<div class="search-filter__group">
+								<div class="search-filter__group-header">
+									<label class="search-filter__group-title">선택된 필터</label>
+									<button type="button" class="search-filter__reset-button">초기화</button>
 								</div>
-								<div class="content-list__col content-list__col--coed" data-label="공학여부">
-									${school.hsCoeduType}</div>
-								<div class="content-list__col content-list__col--type" data-label="학교유형">
-									${school.hsTypeName}</div>
-								<div class="content-list__col content-list__col--found" data-label="설립유형">
-									${school.hsFoundType}</div>
-								<div class="content-list__col content-list__col--region" data-label="지역">
-									${school.hsRegion}</div>
+								<div class="search-filter__selected-tags"></div>
 							</div>
-						</c:forEach>
-						<c:if test="${articlePage.total == 0}">
-							<p class="content-list__no-results">검색 결과가 없습니다.</p>
-						</c:if>
-					</div>
-
-					<div class="pagination">
-						<c:url var="prevUrl" value="${articlePage.url}">
-							<c:param name="currentPage" value="${articlePage.startPage - 5}" />
-							<c:if test="${not empty param.keyword}">
-								<c:param name="keyword" value="${param.keyword}" />
-							</c:if>
-							<c:forEach var="regionValue" items="${paramValues.regionFilter}">
-								<c:param name="regionFilter" value="${regionValue}" />
-							</c:forEach>
-							<c:forEach var="schoolTypeValue" items="${paramValues.schoolType}">
-								<c:param name="schoolType" value="${schoolTypeValue}" />
-							</c:forEach>
-							<c:forEach var="coedTypeValue" items="${paramValues.coedTypeFilter}">
-								<c:param name="coedTypeFilter" value="${coedTypeValue}" />
-							</c:forEach>
-						</c:url>
-						<a href="${prevUrl}"
-							class="pagination__link ${articlePage.startPage < 6 ? 'pagination__link--disabled' : ''}"> ←
-							Previous </a>
-
-						<c:forEach var="pNo" begin="${articlePage.startPage}" end="${articlePage.endPage}">
-							<c:url var="pageUrl" value="${articlePage.url}">
-								<c:param name="currentPage" value="${pNo}" />
-								<c:if test="${not empty param.keyword}">
-									<c:param name="keyword" value="${param.keyword}" />
-								</c:if>
-								<c:forEach var="regionValue" items="${paramValues.regionFilter}">
-									<c:param name="regionFilter" value="${regionValue}" />
-								</c:forEach>
-								<c:forEach var="schoolTypeValue" items="${paramValues.schoolType}">
-									<c:param name="schoolType" value="${schoolTypeValue}" />
-								</c:forEach>
-								<c:forEach var="coedTypeValue" items="${paramValues.coedTypeFilter}">
-									<c:param name="coedTypeFilter" value="${coedTypeValue}" />
-								</c:forEach>
-							</c:url>
-							<a href="${pageUrl}"
-								class="pagination__link ${pNo == articlePage.currentPage ? 'pagination__link--active' : ''}">
-								${pNo} </a>
-						</c:forEach>
-
-						<c:url var="nextUrl" value="${articlePage.url}">
-							<c:param name="currentPage" value="${articlePage.startPage + 5}" />
-							<c:if test="${not empty param.keyword}">
-								<c:param name="keyword" value="${param.keyword}" />
-							</c:if>
-							<c:forEach var="regionValue" items="${paramValues.regionFilter}">
-								<c:param name="regionFilter" value="${regionValue}" />
-							</c:forEach>
-							<c:forEach var="schoolTypeValue" items="${paramValues.schoolType}">
-								<c:param name="schoolType" value="${schoolTypeValue}" />
-							</c:forEach>
-							<c:forEach var="coedTypeValue" items="${paramValues.coedTypeFilter}">
-								<c:param name="coedTypeFilter" value="${coedTypeValue}" />
-							</c:forEach>
-						</c:url>
-						<a href="${nextUrl}"
-							class="pagination__link ${articlePage.endPage >= articlePage.totalPages ? 'pagination__link--disabled' : ''}">
-							Next → </a>
+							<button type="submit" class="search-filter__submit-button">검색</button>
+						</div>
 					</div>
 				</div>
+			</form>
+			<span class="list-header__meta-item list-header__meta-item--source">[ 출처 : 나이스 교육정보 개방 포털(NEIS)]</span>
+			<div class="content-list">
+				<div class="content-list__header">
+					<span class="content-list__col content-list__col--school-name">학교명</span>
+					<span class="content-list__col content-list__col--coed">공학여부</span>
+					<span class="content-list__col content-list__col--type">학교유형</span>
+					<span class="content-list__col content-list__col--found">설립유형</span>
+					<span class="content-list__col content-list__col--region">지역</span>
+				</div>
+				<c:forEach var="school" items="${articlePage.content}">
+					<div class="content-list__item" data-hs-id="${school.hsId}">
+						<div class="content-list__col content-list__col--school-name" data-label="학교명">
+							<h3 class="content-list__title">${school.hsName}</h3>
+						</div>
+						<div class="content-list__col content-list__col--coed" data-label="공학여부">${school.hsCoeduType}</div>
+						<div class="content-list__col content-list__col--type" data-label="학교유형">${school.hsTypeName}</div>
+						<div class="content-list__col content-list__col--found" data-label="설립유형">${school.hsFoundType}</div>
+						<div class="content-list__col content-list__col--region" data-label="지역">${school.hsRegion}</div>
+					</div>
+				</c:forEach>
+				<c:if test="${articlePage.total == 0}">
+					<p class="content-list__no-results">검색 결과가 없습니다.</p>
+				</c:if>
+			</div>
+
+			<div class="pagination">
+				<c:url var="prevUrl" value="${articlePage.url}">
+					<c:param name="currentPage" value="${articlePage.startPage - 5}" />
+					<c:if test="${not empty param.keyword}">
+						<c:param name="keyword" value="${param.keyword}" />
+					</c:if>
+					<c:forEach var="regionValue" items="${paramValues.regionFilter}">
+						<c:param name="regionFilter" value="${regionValue}" />
+					</c:forEach>
+					<c:forEach var="schoolTypeValue" items="${paramValues.schoolType}">
+						<c:param name="schoolType" value="${schoolTypeValue}" />
+					</c:forEach>
+					<c:forEach var="coedTypeValue" items="${paramValues.coedTypeFilter}">
+						<c:param name="coedTypeFilter" value="${coedTypeValue}" />
+					</c:forEach>
+				</c:url>
+				<a href="${prevUrl}" class="pagination__link ${articlePage.startPage < 6 ? 'pagination__link--disabled' : ''}"> ← Previous </a>
+
+				<c:forEach var="pNo" begin="${articlePage.startPage}" end="${articlePage.endPage}">
+					<c:url var="pageUrl" value="${articlePage.url}">
+						<c:param name="currentPage" value="${pNo}" />
+						<c:if test="${not empty param.keyword}">
+							<c:param name="keyword" value="${param.keyword}" />
+						</c:if>
+						<c:forEach var="regionValue" items="${paramValues.regionFilter}">
+							<c:param name="regionFilter" value="${regionValue}" />
+						</c:forEach>
+						<c:forEach var="schoolTypeValue" items="${paramValues.schoolType}">
+							<c:param name="schoolType" value="${schoolTypeValue}" />
+						</c:forEach>
+						<c:forEach var="coedTypeValue" items="${paramValues.coedTypeFilter}">
+							<c:param name="coedTypeFilter" value="${coedTypeValue}" />
+						</c:forEach>
+					</c:url>
+					<a href="${pageUrl}" class="pagination__link ${pNo == articlePage.currentPage ? 'pagination__link--active' : ''}"> ${pNo} </a>
+				</c:forEach>
+
+				<c:url var="nextUrl" value="${articlePage.url}">
+					<c:param name="currentPage" value="${articlePage.startPage + 5}" />
+					<c:if test="${not empty param.keyword}">
+						<c:param name="keyword" value="${param.keyword}" />
+					</c:if>
+					<c:forEach var="regionValue" items="${paramValues.regionFilter}">
+						<c:param name="regionFilter" value="${regionValue}" />
+					</c:forEach>
+					<c:forEach var="schoolTypeValue" items="${paramValues.schoolType}">
+						<c:param name="schoolType" value="${schoolTypeValue}" />
+					</c:forEach>
+					<c:forEach var="coedTypeValue" items="${paramValues.coedTypeFilter}">
+						<c:param name="coedTypeFilter" value="${coedTypeValue}" />
+					</c:forEach>
+				</c:url>
+				<a href="${nextUrl}" class="pagination__link ${articlePage.endPage >= articlePage.totalPages ? 'pagination__link--disabled' : ''}"> Next → </a>
 			</div>
 		</div>
-		<%@ include file="/WEB-INF/views/include/footer.jsp" %>
-			</body>
+	</div>
+</div>
+<%@ include file="/WEB-INF/views/include/footer.jsp"%>
+</body>
 
-			</html>
-			<script src="/js/ertds/hgschl/HighSchoolList.js"></script>
+</html>
+<script src="/js/ertds/hgschl/HighSchoolList.js"></script>

--- a/src/main/webapp/WEB-INF/views/ertds/qlfexm/selectQlfexmDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/qlfexm/selectQlfexmDetail.jsp
@@ -1,6 +1,25 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/ertds/qlfexm/selectQlfexmDetail.css">
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진학 정보</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-item">
+			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+		</div>
+		<div class="channel-sub-section-itemIn">
+			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
+		</div>
+	</div>
+</section>
 <div class="breadcrumb-container-space">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
@@ -10,7 +29,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학 정보</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
@@ -20,6 +39,9 @@
 </div>
 
 <div class="public-wrapper">
+	<div class="tab-container" id="tabs">
+		<a class="tab active" href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+	</div>
 	<div class="public-wrapper-main">
 		<div class="detail__header-wrapper">
 			<div class="detail__header">

--- a/src/main/webapp/WEB-INF/views/ertds/qlfexm/selectQlfexmDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/qlfexm/selectQlfexmDetail.jsp
@@ -40,7 +40,7 @@
 
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
-		<a class="tab active" href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+		<a class="tab active" href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
 	</div>
 	<div class="public-wrapper-main">
 		<div class="detail__header-wrapper">

--- a/src/main/webapp/WEB-INF/views/ertds/qlfexm/selectQlfexmDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/qlfexm/selectQlfexmDetail.jsp
@@ -1,28 +1,25 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/ertds/qlfexm/selectQlfexmDetail.css">
-<section class="channel">
-	<div class="channel-title">
-		<div class="channel-title-text">진학 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-item">
-			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
-		</div>
-		<div class="channel-sub-section-itemIn">
-			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 
 <div class="public-wrapper">
-	<div class="tab-container" id="tabs">
-		<h3 class="page-title-bar__title">검정고시</h3>
-	</div>
-
 	<div class="public-wrapper-main">
 		<div class="detail__header-wrapper">
 			<div class="detail__header">
@@ -41,12 +38,12 @@
 				<span class="detail-header__meta-item detail-header__meta-item--source">[ 출처 : 국가평생교육진흥원 검정고시지원센터 ]</span>
 			</div>
 		</div>
-			<hr class="detail__divider" />
-			
+		<hr class="detail__divider" />
+
 		<div class="detail__content">
 			<div class="exam-notice notice-content">${qualficationExamVO.examContent}</div>
 		</div>
-		
+
 		<div class="detail__back-to-list">
 			<a href="/ertds/qlfexm/selectQlfexmList.do" class="detail__action-button">목 록</a>
 		</div>

--- a/src/main/webapp/WEB-INF/views/ertds/qlfexm/selectQlfexmList.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/qlfexm/selectQlfexmList.jsp
@@ -1,6 +1,25 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/ertds/qlfexm/selectQlfexmList.css">
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진학 정보</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-item">
+			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+		</div>
+		<div class="channel-sub-section-itemIn">
+			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
+		</div>
+	</div>
+</section>
 <div class="breadcrumb-container-space">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
@@ -10,7 +29,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학 정보</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
@@ -20,6 +39,9 @@
 </div>
 <div>
 	<div class="public-wrapper">
+		<div class="tab-container" id="tabs">
+			<a class="tab active" href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
+		</div>
 		<div class="public-wrapper-main">
 			<form method="get" action="/ertds/qlfexm/selectQlfexmList.do" class="search-filter__form">
 				<div class="search-filter__bar">

--- a/src/main/webapp/WEB-INF/views/ertds/qlfexm/selectQlfexmList.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/qlfexm/selectQlfexmList.jsp
@@ -1,29 +1,25 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/ertds/qlfexm/selectQlfexmList.css">
-<section class="channel">
-	<div class="channel-title">
-		<div class="channel-title-text">진학 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-item">
-			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
-		</div>
-		<!-- 중분류 -->
-		<div class="channel-sub-section-item">
-			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
-		</div>
-		<div class="channel-sub-section-itemIn">
-			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
-		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">검정고시</h3>
-		</div>
-
 		<div class="public-wrapper-main">
 			<form method="get" action="/ertds/qlfexm/selectQlfexmList.do" class="search-filter__form">
 				<div class="search-filter__bar">

--- a/src/main/webapp/WEB-INF/views/ertds/univ/dpsrch/selectCompare.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/dpsrch/selectCompare.jsp
@@ -18,7 +18,23 @@
 		</div>
 	</div>
 </section>
-
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학 정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/ertds/univ/dpsrch/selectDeptList.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/dpsrch/selectDeptList.jsp
@@ -1,6 +1,25 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/ertds/univ/dpsrch/deptList.css">
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진학 정보</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-itemIn">
+			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
+		</div>
+	</div>
+</section>
 <div class="breadcrumb-container-space">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
@@ -10,7 +29,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학 정보</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>

--- a/src/main/webapp/WEB-INF/views/ertds/univ/dpsrch/selectDeptList.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/dpsrch/selectDeptList.jsp
@@ -1,22 +1,23 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/ertds/univ/dpsrch/deptList.css">
-<section class="channel">
-	<div class="channel-title">
-		<div class="channel-title-text">진학 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-itemIn">
-			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/ertds/univ/dpsrch/selectDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/dpsrch/selectDetail.jsp
@@ -2,7 +2,25 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/common/selectDetailPage.css">
-
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진학 정보</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-itemIn">
+			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
+		</div>
+	</div>
+</section>
 <div class="breadcrumb-container-space">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
@@ -12,7 +30,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학 정보</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>

--- a/src/main/webapp/WEB-INF/views/ertds/univ/dpsrch/selectDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/dpsrch/selectDetail.jsp
@@ -3,22 +3,23 @@
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/common/selectDetailPage.css">
 
-<section class="channel">
-	<div class="channel-title">
-		<div class="channel-title-text">진학 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-itemIn">
-			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 
 <div>
 	<div class="public-wrapper">

--- a/src/main/webapp/WEB-INF/views/ertds/univ/uvivfb/insertInterviewFeedbackView.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/uvivfb/insertInterviewFeedbackView.jsp
@@ -22,6 +22,23 @@
 		</div>
 	</div>
 </section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학 정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<!-- 여기는 소분류(tab이라 명칭지음)인데 사용안하는곳은 주석처리 하면됩니다 -->

--- a/src/main/webapp/WEB-INF/views/ertds/univ/uvivfb/selectInterviewList.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/uvivfb/selectInterviewList.jsp
@@ -1,22 +1,23 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/ertds/univ/uvivfb/selectInterviewList.css">
-<section class="channel">
-	<div class="channel-title">
-		<div class="channel-title-text">진학 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-itemIn">
-			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
@@ -48,10 +49,10 @@
 					</div>
 				</div>
 			</form>
-			
+
 			<div class="content-list">
 				<div class="accordion-list__header">
-						<span class="accordion-list__col accordion-list__col--univ-name">대학명</span>
+					<span class="accordion-list__col accordion-list__col--univ-name">대학명</span>
 					<div class="accordion-list__col accordion-list__col--meta">
 						<span class="accordion-list__col accordion-list__col--author">작성자</span>
 						<span class="accordion-list__col accordion-list__col--date">작성일</span>
@@ -146,12 +147,8 @@
 								</div>
 								<c:if test="${pageContext.request.userPrincipal.principal == content.memId}">
 									<div class="card-actions">
-										<button type="button" class="card-actions__button card-actions__button--edit" data-mem-id="${content.memId}" data-ir-id="${content.irId}">
-										수정
-										</button>
-										<button type="button" class="card-actions__button card-actions__button--delete" data-ir-id="${content.irId}">
-										삭제
-										</button>
+										<button type="button" class="card-actions__button card-actions__button--edit" data-mem-id="${content.memId}" data-ir-id="${content.irId}">수정</button>
+										<button type="button" class="card-actions__button card-actions__button--delete" data-ir-id="${content.irId}">삭제</button>
 									</div>
 								</c:if>
 							</div>
@@ -162,11 +159,11 @@
 					<p class="content-list__no-results">면접 후기가 없습니다.</p>
 				</c:if>
 			</div>
-			
+
 			<div class="page-actions">
 				<button id="btnWrite" class="page-actions__button">면접 후기 공유하기</button>
 			</div>
-			
+
 			<div class="pagination">
 				<c:url var="prevUrl" value="${articlePage.url}">
 					<c:param name="currentPage" value="${articlePage.startPage - 5}" />
@@ -178,10 +175,8 @@
 						</c:if>
 					</c:forEach>
 				</c:url>
-				<a href="${prevUrl}" class="pagination__link ${articlePage.startPage < 6 ? 'pagination__link--disabled' : ''}">
-					← Previous
-				</a>
-			
+				<a href="${prevUrl}" class="pagination__link ${articlePage.startPage < 6 ? 'pagination__link--disabled' : ''}"> ← Previous </a>
+
 				<c:forEach var="pNo" begin="${articlePage.startPage}" end="${articlePage.endPage}">
 					<c:url var="pageUrl" value="${articlePage.url}">
 						<c:param name="currentPage" value="${pNo}" />
@@ -193,11 +188,9 @@
 							</c:if>
 						</c:forEach>
 					</c:url>
-					<a href="${pageUrl}" class="pagination__link ${pNo == articlePage.currentPage ? 'pagination__link--active' : ''}">
-						${pNo}
-					</a>
+					<a href="${pageUrl}" class="pagination__link ${pNo == articlePage.currentPage ? 'pagination__link--active' : ''}"> ${pNo} </a>
 				</c:forEach>
-			
+
 				<c:url var="nextUrl" value="${articlePage.url}">
 					<c:param name="currentPage" value="${articlePage.startPage + 5}" />
 					<c:forEach var="p" items="${param}">
@@ -208,9 +201,7 @@
 						</c:if>
 					</c:forEach>
 				</c:url>
-				<a href="${nextUrl}" class="pagination__link ${articlePage.endPage >= articlePage.totalPages ? 'pagination__link--disabled' : ''}">
-					Next →
-				</a>
+				<a href="${nextUrl}" class="pagination__link ${articlePage.endPage >= articlePage.totalPages ? 'pagination__link--disabled' : ''}"> Next → </a>
 			</div>
 		</div>
 	</div>

--- a/src/main/webapp/WEB-INF/views/ertds/univ/uvivfb/selectInterviewList.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/uvivfb/selectInterviewList.jsp
@@ -1,6 +1,25 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/ertds/univ/uvivfb/selectInterviewList.css">
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진학 정보</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-itemIn">
+			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
+		</div>
+	</div>
+</section>
 <div class="breadcrumb-container-space">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
@@ -10,7 +29,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학 정보</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>

--- a/src/main/webapp/WEB-INF/views/ertds/univ/uvivfb/updateInterViewFeedbackView.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/uvivfb/updateInterViewFeedbackView.jsp
@@ -22,6 +22,23 @@
 		</div>
 	</div>
 </section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학 정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<!-- 여기는 소분류(tab이라 명칭지음)인데 사용안하는곳은 주석처리 하면됩니다 -->

--- a/src/main/webapp/WEB-INF/views/ertds/univ/uvsrch/selectDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/uvsrch/selectDetail.jsp
@@ -2,22 +2,23 @@
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/ertds/univ/uvsrch/univDetail.css">
 
-<section class="channel">
-	<div class="channel-title">
-		<div class="channel-title-text">진학 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-itemIn">
-			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 
 <div>
 	<div class="public-wrapper">

--- a/src/main/webapp/WEB-INF/views/ertds/univ/uvsrch/selectDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/uvsrch/selectDetail.jsp
@@ -1,7 +1,25 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/ertds/univ/uvsrch/univDetail.css">
-
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진학 정보</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-itemIn">
+			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
+		</div>
+	</div>
+</section>
 <div class="breadcrumb-container-space">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
@@ -11,7 +29,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학 정보</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>

--- a/src/main/webapp/WEB-INF/views/ertds/univ/uvsrch/selectUnivList.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/uvsrch/selectUnivList.jsp
@@ -2,26 +2,23 @@
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/ertds/univ/uvsrch/univList.css">
 <!-- 스타일 여기 적어주시면 가능 -->
-<section class="channel">
-	<!-- 	여기가 네비게이션 역할을 합니다.  -->
-	<div class="channel-title">
-		<!-- 대분류 -->
-		<div class="channel-title-text">진학 정보</div>
-	</div>
-	<div class="channel-sub-sections">
-		<!-- 중분류 -->
-		<div class="channel-sub-section-itemIn">
-			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
-		</div>
-		<!-- 중분류 -->
-		<div class="channel-sub-section-item">
-			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/ertds/univ/uvsrch/selectUnivList.jsp
+++ b/src/main/webapp/WEB-INF/views/ertds/univ/uvsrch/selectUnivList.jsp
@@ -2,6 +2,25 @@
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/ertds/univ/uvsrch/univList.css">
 <!-- 스타일 여기 적어주시면 가능 -->
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진학 정보</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-itemIn">
+			<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/hgschl/selectHgschList.do">고등학교 정보</a>
+		</div>
+		<div class="channel-sub-section-item">
+			<a href="/ertds/qlfexm/selectQlfexmList.do">검정고시</a>
+		</div>
+	</div>
+</section>
 <div class="breadcrumb-container-space">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
@@ -11,7 +30,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학정보</a>
+				<a href="/ertds/univ/uvsrch/selectUnivList.do">진학 정보</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/ertds/univ/uvsrch/selectUnivList.do">대학교 정보</a>

--- a/src/main/webapp/WEB-INF/views/mpg/mat/bmk/selectBookmarkList.jsp
+++ b/src/main/webapp/WEB-INF/views/mpg/mat/bmk/selectBookmarkList.jsp
@@ -20,6 +20,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/mpg/mif/inq/selectMyInquiryView.do">마이페이지</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/mpg/mat/bmk/selectBookMarkList.do">나의 활동</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<!-- 여기는 소분류(tab이라 명칭지음)인데 사용안하는곳은 주석처리 하면됩니다 -->

--- a/src/main/webapp/WEB-INF/views/mpg/mat/csh/selectCounselingHistoryList.jsp
+++ b/src/main/webapp/WEB-INF/views/mpg/mat/csh/selectCounselingHistoryList.jsp
@@ -17,6 +17,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/mpg/mif/inq/selectMyInquiryView.do">마이페이지</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/mpg/mat/bmk/selectBookMarkList.do">나의 활동</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/mpg/mat/reh/selectResumeHistoryList.jsp
+++ b/src/main/webapp/WEB-INF/views/mpg/mat/reh/selectResumeHistoryList.jsp
@@ -19,6 +19,24 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/mpg/mif/inq/selectMyInquiryView.do">마이페이지</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/mpg/mat/bmk/selectBookMarkList.do">나의 활동</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
 		<a class="tab" href="/mpg/mat/bmk/selectBookMarkList.do">북마크</a>

--- a/src/main/webapp/WEB-INF/views/mpg/mat/sih/selectSelfIntroHistoryList.jsp
+++ b/src/main/webapp/WEB-INF/views/mpg/mat/sih/selectSelfIntroHistoryList.jsp
@@ -19,6 +19,24 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/mpg/mif/inq/selectMyInquiryView.do">마이페이지</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/mpg/mat/bmk/selectBookMarkList.do">나의 활동</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
 		<a class="tab" href="/mpg/mat/bmk/selectBookMarkList.do">북마크</a>

--- a/src/main/webapp/WEB-INF/views/mpg/mif/inq/selectMyInquiryView.jsp
+++ b/src/main/webapp/WEB-INF/views/mpg/mif/inq/selectMyInquiryView.jsp
@@ -23,6 +23,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/mpg/mif/inq/selectMyInquiryView.do">마이페이지</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/mpg/mif/inq/selectMyInquiryView.do">내 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper" data-success-message="${successMessage}" data-error-message="${errorMessage}">
 		<!-- 여기는 소분류(tab이라 명칭지음)인데 사용안하는곳은 주석처리 하면됩니다 -->

--- a/src/main/webapp/WEB-INF/views/mpg/mif/inq/selectMyInquiryView.jsp
+++ b/src/main/webapp/WEB-INF/views/mpg/mif/inq/selectMyInquiryView.jsp
@@ -1,9 +1,10 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/mpg/mif/inq/selectMyInquiryView.css">
+<script src="https://cdn.iamport.kr/v1/iamport.js"></script>
 
 <!-- 스타일 여기 적어주시면 가능 -->
-<section class="channel" data-success-message="${successMessage}" data-error-message="${errorMessage}">
+<section class="channel" >
 	<!-- 	여기가 네비게이션 역할을 합니다.  -->
 	<div class="channel-title">
 		<!-- 대분류 -->
@@ -23,7 +24,7 @@
 	</div>
 </section>
 <div>
-	<div class="public-wrapper">
+	<div class="public-wrapper" data-success-message="${successMessage}" data-error-message="${errorMessage}">
 		<!-- 여기는 소분류(tab이라 명칭지음)인데 사용안하는곳은 주석처리 하면됩니다 -->
 		<div class="tab-container" id="tabs">
 			<a class="tab active" href="/mpg/mif/inq/selectMyInquiryView.do">조회 및 수정</a>
@@ -86,7 +87,7 @@
 								<div class="info-item">
 									<label>연락처</label>
 									<span class="info-value">${member.memPhoneNumber}</span>
-									<button type="button" class="detail__action-button detail__action-button--auth">번호 변경</button>
+									<button type="button" class="detail__action-button detail__action-button--auth" id="phoneChangeBtn">번호 변경</button>
 								</div>
 								<div class="info-item">
 									<label>생년월일</label>

--- a/src/main/webapp/WEB-INF/views/mpg/mif/pswdchg/selectPasswordChangeView.jsp
+++ b/src/main/webapp/WEB-INF/views/mpg/mif/pswdchg/selectPasswordChangeView.jsp
@@ -21,6 +21,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/mpg/mif/inq/selectMyInquiryView.do">마이페이지</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/mpg/mif/inq/selectMyInquiryView.do">내 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<!-- 여기는 소분류(tab이라 명칭지음)인데 사용안하는곳은 주석처리 하면됩니다 -->

--- a/src/main/webapp/WEB-INF/views/mpg/mif/whdwl/selectWithdrawalView.jsp
+++ b/src/main/webapp/WEB-INF/views/mpg/mif/whdwl/selectWithdrawalView.jsp
@@ -20,6 +20,26 @@
 		</div>
 	</div>
 </section>
+
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/mpg/mif/inq/selectMyInquiryView.do">마이페이지</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/mpg/mif/inq/selectMyInquiryView.do">내 정보</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<!-- 여기는 소분류(tab이라 명칭지음)인데 사용안하는곳은 주석처리 하면됩니다 -->

--- a/src/main/webapp/WEB-INF/views/mpg/pay/selectPaymentView.jsp
+++ b/src/main/webapp/WEB-INF/views/mpg/pay/selectPaymentView.jsp
@@ -21,11 +21,29 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/mpg/mif/inq/selectMyInquiryView.do">마이페이지</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/mpg/pay/selectPaymentView.do">결제 구독내역</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
-		<!-- 여기부터 작성해 주시면 됩니다 -->
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">결제/구독내역</h3>
+			<a class="tab active" href="/mpg/pay/selectPaymentView.do">결제/구독내역</a>
 		</div>
 		
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/prg/act/cr/crDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/prg/act/cr/crDetail.jsp
@@ -17,11 +17,30 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/prg/ctt/cttList.do">프로그램</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/prg/act/vol/volList.do">대외활동</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
 			<a class="tab" href="/prg/act/vol/volList.do">봉사활동</a>
-			<a class="tab active" href="/prg/act/cr/crList.do">직업체험</a>
+			<a class="tab active" href="/prg/act/cr/crList.do">인턴십</a>
 			<a class="tab" href="/prg/act/sup/supList.do">서포터즈</a>
 		</div>
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/prg/act/cr/crList.jsp
+++ b/src/main/webapp/WEB-INF/views/prg/act/cr/crList.jsp
@@ -18,6 +18,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/prg/ctt/cttList.do">프로그램</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/prg/act/vol/volList.do">대외활동</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/prg/act/sup/supDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/prg/act/sup/supDetail.jsp
@@ -17,11 +17,30 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/prg/ctt/cttList.do">프로그램</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/prg/act/vol/volList.do">대외활동</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
 			<a class="tab" href="/prg/act/vol/volList.do">봉사활동</a>
-			<a class="tab" href="/prg/act/cr/crList.do">직업체험</a>
+			<a class="tab" href="/prg/act/cr/crList.do">인턴십</a>
 			<a class="tab active" href="/prg/act/sup/supList.do">서포터즈</a>
 		</div>
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/prg/act/sup/supList.jsp
+++ b/src/main/webapp/WEB-INF/views/prg/act/sup/supList.jsp
@@ -18,6 +18,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/prg/ctt/cttList.do">프로그램</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/prg/act/vol/volList.do">대외활동</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/prg/act/vol/volDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/prg/act/vol/volDetail.jsp
@@ -17,11 +17,30 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/prg/ctt/cttList.do">프로그램</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/prg/act/vol/volList.do">대외활동</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
 			<a class="tab active" href="/prg/act/vol/volList.do">봉사활동</a>
-			<a class="tab" href="/prg/act/cr/crList.do">직업체험</a>
+			<a class="tab" href="/prg/act/cr/crList.do">인턴십</a>
 			<a class="tab" href="/prg/act/sup/supList.do">서포터즈</a>
 		</div>
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/prg/act/vol/volList.jsp
+++ b/src/main/webapp/WEB-INF/views/prg/act/vol/volList.jsp
@@ -18,6 +18,25 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/prg/ctt/cttList.do">프로그램</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/prg/act/vol/volList.do">대외활동</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/prg/ctt/cttDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/prg/ctt/cttDetail.jsp
@@ -17,10 +17,29 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/prg/ctt/cttList.do">프로그램</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/prg/ctt/cttList.do">공모전</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">공모전</h3>
+			<a class="tab active" href="/prg/ctt/cttList.do">공모전</a>
 		</div>
 		<div class="public-wrapper-main">
 			<div class="detail-title-wrapper">

--- a/src/main/webapp/WEB-INF/views/prg/ctt/cttList.jsp
+++ b/src/main/webapp/WEB-INF/views/prg/ctt/cttList.jsp
@@ -22,9 +22,27 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/prg/ctt/cttList.do">프로그램</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/prg/ctt/cttList.do">공모전</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
-		<h3 class="page-title-bar__title">공모전</h3>
+		<a class="tab active" href="/prg/ctt/cttList.do">공모전</a>
 	</div>
 
 	<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/prg/std/createStdGroup.jsp
+++ b/src/main/webapp/WEB-INF/views/prg/std/createStdGroup.jsp
@@ -23,9 +23,27 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/prg/ctt/cttList.do">프로그램</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/prg/std/stdGroupList.do">스터디 그룹</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div class="public-wrapper">
 	<div class="tab-container" id="tabs">
-		<h3 class="page-title-bar__title">스터디 그룹</h3>
+		<a class="tab active" href="/prg/std/stdGroupList.do">스터디 그룹</a>
 	</div>
 
 	<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/prg/std/stdGroupDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/prg/std/stdGroupDetail.jsp
@@ -17,13 +17,32 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/prg/ctt/cttList.do">프로그램</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/prg/std/stdGroupList.do">스터디 그룹</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<sec:authorize access="isAuthenticated()">
 		<sec:authentication property="principal" var="memId" />
 	</sec:authorize>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">스터디 그룹</h3>
+			<a class="tab active" href="/prg/std/stdGroupList.do">스터디 그룹</a>
 		</div>
 
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/prg/std/stdGroupList.jsp
+++ b/src/main/webapp/WEB-INF/views/prg/std/stdGroupList.jsp
@@ -17,10 +17,29 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/prg/ctt/cttList.do">프로그램</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/prg/std/stdGroupList.do">스터디 그룹</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">스터디 그룹</h3>
+			<a class="tab active" href="/prg/std/stdGroupList.do">스터디 그룹</a>
 		</div>
 
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/prg/std/updateStdBoard.jsp
+++ b/src/main/webapp/WEB-INF/views/prg/std/updateStdBoard.jsp
@@ -17,11 +17,31 @@
 		</div>
 	</div>
 </section>
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/prg/ctt/cttList.do">프로그램</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/prg/std/stdGroupList.do">스터디 그룹</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">스터디 그룹</h3>
+			<a class="tab active" href="/prg/std/stdGroupList.do">스터디 그룹</a>
 		</div>
+		
 		<div class="public-wrapper-main">
 			<h2 class="studygroup-from__title">스터디그룹 소개 및 채팅방 수정</h2>
 			<p class="studygroup-form__subtitle">스터디그룹 모집 게시글을 수정합니다.</p>

--- a/src/main/webapp/WEB-INF/views/pse/cat/careerAptitudeTestView.jsp
+++ b/src/main/webapp/WEB-INF/views/pse/cat/careerAptitudeTestView.jsp
@@ -1,73 +1,74 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8"
-	pageEncoding="UTF-8"%>
-<%@ include file="/WEB-INF/views/include/header.jsp"%>
-<link rel="stylesheet" href="/css/pse/cat/careerAptitudeTestView.css">
-<sec:authorize access="hasRole('ROLE_USER')">
-  <script>window.isLoggedIn = true;</script>
-</sec:authorize>
-<sec:authorize access="!isAuthenticated()">
-  <script>window.isLoggedIn = false;</script>
-</sec:authorize>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+	<%@ include file="/WEB-INF/views/include/header.jsp" %>
+		<link rel="stylesheet" href="/css/pse/cat/careerAptitudeTestView.css">
+		<sec:authorize access="hasRole('ROLE_USER')">
+			<script>
+				window.isLoggedIn = true;
+			</script>
+		</sec:authorize>
+		<sec:authorize access="!isAuthenticated()">
+			<script>
+				window.isLoggedIn = false;
+			</script>
+		</sec:authorize>
 
-<section class="channel">
-	<div class="channel-title">
-		<h2 class="channel-title-text">진로 탐색</h2>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-itemIn">
-			<a href="/pse/cat/careerAptitudeTest.do">진로 심리검사</a>
-		</div>
-		<div class="channel-sub-section-item">
-			<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>
-		</div>
-	</div>
-</section>
 
-<div>
-	<div class="public-wrapper">
-		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">진로 심리검사</h3>
+		<div class="breadcrumb-container-space">
+			<nav class="breadcrumb-container" aria-label="breadcrumb">
+				<ol class="breadcrumb">
+					<li class="breadcrumb-item">
+						<a href="/">
+							<i class="fa-solid fa-house"></i> 홈
+						</a>
+					</li>
+					<li class="breadcrumb-item">
+						<a href="/pse/cat/careerAptitudeTest.do">진로탐색</a>
+					</li>
+					<li class="breadcrumb-item active">
+						<a href="/pse/cat/careerAptitudeTest.do">진로 심리검사</a>
+					</li>
+				</ol>
+			</nav>
 		</div>
-		<div class="public-wrapper-main">
-			
-			<div class="test-intro">
-				<span class="list-header__meta-item list-header__meta-item--source">[ 출처 : 한국직업능력연구원 국가진로교육연구센터 (커리어넷) ]</span>
-				<h2 class="test-intro__title">진로 심리검사 안내</h2>
-				<p class="test-intro__subtitle">
-					나를 바로 알면 <strong>성공한 미래</strong>가 보인다!
-				</p>
-				<p class="test-intro__description">
-					진로심리검사는 자신의 흥미와 성격, 가치관을 기반으로 진로를 탐색할 수 있도록 도와줍니다.<br> 다른
-					검사결과는 진단 후 결과만 제공하지만, 진로심리검사는 검사 후 진로 정보와 직업 정보를 함께 제공함으로써 실제 진로로
-					발전할 수 있는 방향까지 안내합니다.<br> 자신에게 맞는 심리를 선택하여 검사하고, 검사 결과를 바탕으로
-					진로를 개발하기 위한 첫 걸음을 내딛기 바랍니다.
-				</p>
+		<div class="public-wrapper">
+			<div class="public-wrapper-main">
+				<div class="test-intro">
+					<span class="list-header__meta-item list-header__meta-item--source">[ 출처 : 한국직업능력연구원 국가진로교육연구센터
+						(커리어넷) ]</span>
+					<h2 class="test-intro__title">진로 심리검사 안내</h2>
+					<p class="test-intro__subtitle">
+						나를 바로 알면 <strong>성공한 미래</strong>가 보인다!
+					</p>
+					<p class="test-intro__description">
+						진로심리검사는 자신의 흥미와 성격, 가치관을 기반으로 진로를 탐색할 수 있도록 도와줍니다.<br> 다른 검사결과는 진단 후 결과만 제공하지만, 진로심리검사는 검사 후 진로
+						정보와 직업 정보를 함께 제공함으로써 실제 진로로 발전할 수 있는 방향까지 안내합니다.<br> 자신에게 맞는 심리를 선택하여 검사하고, 검사 결과를 바탕으로 진로를 개발하기
+						위한 첫 걸음을 내딛기 바랍니다.
+					</p>
 
-				<div class="test-intro__features">
-					<div class="test-intro__feature-item test-intro__feature-item--pink">
-						진로목표가<br>나는 누구인가<br>어떤꿈인가?
+					<div class="test-intro__features">
+						<div class="test-intro__feature-item test-intro__feature-item--pink">
+							진로목표가<br>나는 누구인가<br>어떤꿈인가?
+						</div>
+						<div class="test-intro__feature-item test-intro__feature-item--blue">
+							진로에서 필요한<br>어떤 성격과 태도가<br>나와 적합한 역할?
+						</div>
+						<div class="test-intro__feature-item test-intro__feature-item--green">
+							진로특성, 진로정보<br>무슨 직무가<br>발달할까?
+						</div>
 					</div>
-					<div class="test-intro__feature-item test-intro__feature-item--blue">
-						진로에서 필요한<br>어떤 성격과 태도가<br>나와 적합한 역할?
+
+					<div class="test-intro__tabs">
+						<button class="test-intro__tab test-intro__tab--active" data-type="student">중·고등학생용</button>
+						<button class="test-intro__tab" data-type="adult">대학·성인용</button>
 					</div>
-					<div class="test-intro__feature-item test-intro__feature-item--green">
-						진로특성, 진로정보<br>무슨 직무가<br>발달할까?
-					</div>
+
+					<div class="test-intro__card-grid" id="cardGrid"></div>
 				</div>
-
-				<div class="test-intro__tabs">
-					<button class="test-intro__tab test-intro__tab--active" data-type="student">중·고등학생용</button>
-					<button class="test-intro__tab" data-type="adult">대학·성인용</button>
-				</div>
-
-				<div class="test-intro__card-grid" id="cardGrid">
-					</div>
 			</div>
-
 		</div>
-	</div>
-</div>
-<%@ include file="/WEB-INF/views/include/footer.jsp"%>
-</body>
-</html>
-<script src="/js/pse/cat/careerAptitudeTestView.js"></script>
+
+		<%@ include file="/WEB-INF/views/include/footer.jsp" %>
+			</body>
+
+			</html>
+			<script src="/js/pse/cat/careerAptitudeTestView.js"></script>

--- a/src/main/webapp/WEB-INF/views/pse/cat/careerAptitudeTestView.jsp
+++ b/src/main/webapp/WEB-INF/views/pse/cat/careerAptitudeTestView.jsp
@@ -1,74 +1,90 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-	<%@ include file="/WEB-INF/views/include/header.jsp" %>
-		<link rel="stylesheet" href="/css/pse/cat/careerAptitudeTestView.css">
-		<sec:authorize access="hasRole('ROLE_USER')">
-			<script>
-				window.isLoggedIn = true;
-			</script>
-		</sec:authorize>
-		<sec:authorize access="!isAuthenticated()">
-			<script>
-				window.isLoggedIn = false;
-			</script>
-		</sec:authorize>
-
-
-		<div class="breadcrumb-container-space">
-			<nav class="breadcrumb-container" aria-label="breadcrumb">
-				<ol class="breadcrumb">
-					<li class="breadcrumb-item">
-						<a href="/">
-							<i class="fa-solid fa-house"></i> 홈
-						</a>
-					</li>
-					<li class="breadcrumb-item">
-						<a href="/pse/cat/careerAptitudeTest.do">진로탐색</a>
-					</li>
-					<li class="breadcrumb-item active">
-						<a href="/pse/cat/careerAptitudeTest.do">진로 심리검사</a>
-					</li>
-				</ol>
-			</nav>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ include file="/WEB-INF/views/include/header.jsp"%>
+<link rel="stylesheet" href="/css/pse/cat/careerAptitudeTestView.css">
+<sec:authorize access="hasRole('ROLE_USER')">
+	<script>
+		window.isLoggedIn = true;
+	</script>
+</sec:authorize>
+<sec:authorize access="!isAuthenticated()">
+	<script>
+		window.isLoggedIn = false;
+	</script>
+</sec:authorize>
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진로 탐색</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-itemIn">
+			<a href="/pse/cat/careerAptitudeTest.do">진로 심리검사</a>
 		</div>
-		<div class="public-wrapper">
-			<div class="public-wrapper-main">
-				<div class="test-intro">
-					<span class="list-header__meta-item list-header__meta-item--source">[ 출처 : 한국직업능력연구원 국가진로교육연구센터
-						(커리어넷) ]</span>
-					<h2 class="test-intro__title">진로 심리검사 안내</h2>
-					<p class="test-intro__subtitle">
-						나를 바로 알면 <strong>성공한 미래</strong>가 보인다!
-					</p>
-					<p class="test-intro__description">
-						진로심리검사는 자신의 흥미와 성격, 가치관을 기반으로 진로를 탐색할 수 있도록 도와줍니다.<br> 다른 검사결과는 진단 후 결과만 제공하지만, 진로심리검사는 검사 후 진로
-						정보와 직업 정보를 함께 제공함으로써 실제 진로로 발전할 수 있는 방향까지 안내합니다.<br> 자신에게 맞는 심리를 선택하여 검사하고, 검사 결과를 바탕으로 진로를 개발하기
-						위한 첫 걸음을 내딛기 바랍니다.
-					</p>
+		<div class="channel-sub-section-item">
+			<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>
+		</div>
+	</div>
+</section>
 
-					<div class="test-intro__features">
-						<div class="test-intro__feature-item test-intro__feature-item--pink">
-							진로목표가<br>나는 누구인가<br>어떤꿈인가?
-						</div>
-						<div class="test-intro__feature-item test-intro__feature-item--blue">
-							진로에서 필요한<br>어떤 성격과 태도가<br>나와 적합한 역할?
-						</div>
-						<div class="test-intro__feature-item test-intro__feature-item--green">
-							진로특성, 진로정보<br>무슨 직무가<br>발달할까?
-						</div>
-					</div>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/pse/cat/careerAptitudeTest.do">진로 탐색</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/pse/cat/careerAptitudeTest.do">진로 심리검사</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+<div class="public-wrapper">
+	<div class="tab-container" id="tabs">
+		<a class="tab active" href="/pse/cat/careerAptitudeTest.do">진로 심리검사</a>
 
-					<div class="test-intro__tabs">
-						<button class="test-intro__tab test-intro__tab--active" data-type="student">중·고등학생용</button>
-						<button class="test-intro__tab" data-type="adult">대학·성인용</button>
-					</div>
+	</div>
+	<div class="public-wrapper-main">
+		<div class="test-intro">
+			<span class="list-header__meta-item list-header__meta-item--source">[ 출처 : 한국직업능력연구원 국가진로교육연구센터 (커리어넷) ]</span>
+			<h2 class="test-intro__title">진로 심리검사 안내</h2>
+			<p class="test-intro__subtitle">
+				나를 바로 알면 <strong>성공한 미래</strong>가 보인다!
+			</p>
+			<p class="test-intro__description">
+				진로심리검사는 자신의 흥미와 성격, 가치관을 기반으로 진로를 탐색할 수 있도록 도와줍니다.<br> 다른 검사결과는 진단 후 결과만 제공하지만, 진로심리검사는 검사 후 진로 정보와 직업 정보를 함께 제공함으로써 실제 진로로 발전할 수 있는 방향까지 안내합니다.<br> 자신에게 맞는 심리를 선택하여 검사하고, 검사 결과를 바탕으로 진로를 개발하기 위한 첫 걸음을 내딛기 바랍니다.
+			</p>
 
-					<div class="test-intro__card-grid" id="cardGrid"></div>
+			<div class="test-intro__features">
+				<div class="test-intro__feature-item test-intro__feature-item--pink">
+					진로목표가<br>나는 누구인가<br>어떤꿈인가?
+				</div>
+				<div class="test-intro__feature-item test-intro__feature-item--blue">
+					진로에서 필요한<br>어떤 성격과 태도가<br>나와 적합한 역할?
+				</div>
+				<div class="test-intro__feature-item test-intro__feature-item--green">
+					진로특성, 진로정보<br>무슨 직무가<br>발달할까?
 				</div>
 			</div>
+
+			<div class="test-intro__tabs">
+				<button class="test-intro__tab test-intro__tab--active" data-type="student">중·고등학생용</button>
+				<button class="test-intro__tab" data-type="adult">대학·성인용</button>
+			</div>
+
+			<div class="test-intro__card-grid" id="cardGrid"></div>
 		</div>
+	</div>
+</div>
 
-		<%@ include file="/WEB-INF/views/include/footer.jsp" %>
-			</body>
+<%@ include file="/WEB-INF/views/include/footer.jsp"%>
+</body>
 
-			</html>
-			<script src="/js/pse/cat/careerAptitudeTestView.js"></script>
+</html>
+<script src="/js/pse/cat/careerAptitudeTestView.js"></script>

--- a/src/main/webapp/WEB-INF/views/pse/cr/cco/careerComparisonView.jsp
+++ b/src/main/webapp/WEB-INF/views/pse/cr/cco/careerComparisonView.jsp
@@ -16,10 +16,28 @@
 	</div>
 </section>
 
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/pse/cat/careerAptitudeTest.do">진로 탐색</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>
+			</li>
+		</ol>
+	</nav>
+</div>
+
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">직업 비교</h3>
+			<a class="tab active" href="#">직업 비교</a>
 		</div>
 	
 		<div class="table-responsive-wrapper">

--- a/src/main/webapp/WEB-INF/views/pse/cr/crl/selectCareerDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/pse/cr/crl/selectCareerDetail.jsp
@@ -2,19 +2,23 @@
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/common/selectDetailPage.css">
 
-<section class="channel" data-error-message="${errorMessage}">
-	<div class="channel-title">
-		<div class="channel-title-text">진로 탐색</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-item">
-			<a href="/pse/cat/careerAptitudeTest.do">진로 심리검사</a>
-		</div>
-		<div class="channel-sub-section-itemIn">
-			<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/pse/cat/careerAptitudeTest.do">진로탐색</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 
 <div>
 	<div class="public-wrapper">

--- a/src/main/webapp/WEB-INF/views/pse/cr/crl/selectCareerDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/pse/cr/crl/selectCareerDetail.jsp
@@ -1,6 +1,22 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/common/selectDetailPage.css">
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진로 탐색</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-item">
+			<a href="/pse/cat/careerAptitudeTest.do">진로 심리검사</a>
+		</div>
+		<div class="channel-sub-section-itemIn">
+			<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>
+		</div>
+	</div>
+</section>
 
 <div class="breadcrumb-container-space">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
@@ -11,7 +27,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/pse/cat/careerAptitudeTest.do">진로탐색</a>
+				<a href="/pse/cat/careerAptitudeTest.do">진로 탐색</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>

--- a/src/main/webapp/WEB-INF/views/pse/cr/crl/selectCareerDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/pse/cr/crl/selectCareerDetail.jsp
@@ -39,7 +39,7 @@
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">
-			<h3 class="page-title-bar__title">직업 상세</h3>
+			<a class="tab active" href="#">직업 상세</a>
 		</div>
 
 		<div class="public-wrapper-main">

--- a/src/main/webapp/WEB-INF/views/pse/cr/crl/selectCareerList.jsp
+++ b/src/main/webapp/WEB-INF/views/pse/cr/crl/selectCareerList.jsp
@@ -1,7 +1,18 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/pse/cr/crl/selectCareerList.css">
-
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진로 탐색</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-item"><a href="/pse/cat/careerAptitudeTest.do">진로 심리검사</a></div>
+		<div class="channel-sub-section-itemIn"><a href="/pse/cr/crl/selectCareerList.do">직업백과</a></div>
+	</div>
+</section>
 
 
 <div class="breadcrumb-container-space">
@@ -13,7 +24,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/pse/cat/careerAptitudeTest.do">진로탐색</a>
+				<a href="/pse/cat/careerAptitudeTest.do">진로 탐색</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>

--- a/src/main/webapp/WEB-INF/views/pse/cr/crl/selectCareerList.jsp
+++ b/src/main/webapp/WEB-INF/views/pse/cr/crl/selectCareerList.jsp
@@ -2,20 +2,25 @@
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/pse/cr/crl/selectCareerList.css">
 
-<section class="channel" data-error-message="${errorMessage}">
-	<div class="channel-title">
-		<div class="channel-title-text">진로 탐색</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-item">
-			<a href="/pse/cat/careerAptitudeTest.do">진로 심리검사</a>
-		</div>
-		<div class="channel-sub-section-itemIn">
-			<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>
-		</div>
-	</div>
-</section>
 
+
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/pse/cat/careerAptitudeTest.do">진로탐색</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 <div>
 	<div class="public-wrapper">
 		<div class="tab-container" id="tabs">

--- a/src/main/webapp/WEB-INF/views/pse/cr/crr/careerEncyclopediaRcmList.jsp
+++ b/src/main/webapp/WEB-INF/views/pse/cr/crr/careerEncyclopediaRcmList.jsp
@@ -2,19 +2,23 @@
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/pse/cr/crl/selectCareerList.css">
 
-<section class="channel" data-error-message="${errorMessage}" data-server-error="${serverError}">
-	<div class="channel-title">
-		<div class="channel-title-text">진로 탐색</div>
-	</div>
-	<div class="channel-sub-sections">
-		<div class="channel-sub-section-item">
-			<a href="/pse/cat/careerAptitudeTest.do">진로 심리검사</a>
-		</div>
-		<div class="channel-sub-section-itemIn">
-			<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>
-		</div>
-	</div>
-</section>
+<div class="breadcrumb-container-space">
+	<nav class="breadcrumb-container" aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				<a href="/">
+					<i class="fa-solid fa-house"></i> 홈
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a href="/pse/cat/careerAptitudeTest.do">진로탐색</a>
+			</li>
+			<li class="breadcrumb-item active">
+				<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>
+			</li>
+		</ol>
+	</nav>
+</div>
 
 <div>
 	<div class="public-wrapper">

--- a/src/main/webapp/WEB-INF/views/pse/cr/crr/careerEncyclopediaRcmList.jsp
+++ b/src/main/webapp/WEB-INF/views/pse/cr/crr/careerEncyclopediaRcmList.jsp
@@ -2,7 +2,24 @@
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/pse/cr/crl/selectCareerList.css">
 
-<div class="breadcrumb-container-space"  data-error-message="${errorMessage}" data-server-error="${serverError}">
+<section class="channel">
+	<!-- 	여기가 네비게이션 역할을 합니다.  -->
+	<div class="channel-title">
+		<!-- 대분류 -->
+		<div class="channel-title-text">진로 탐색</div>
+	</div>
+	<!-- 중분류 -->
+	<div class="channel-sub-sections">
+		<div class="channel-sub-section-item">
+			<a href="/pse/cat/careerAptitudeTest.do">진로 심리검사</a>
+		</div>
+		<div class="channel-sub-section-itemIn">
+			<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>
+		</div>
+	</div>
+</section>
+
+<div class="breadcrumb-container-space" data-error-message="${errorMessage}" data-server-error="${serverError}">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
 			<li class="breadcrumb-item">
@@ -11,7 +28,7 @@
 				</a>
 			</li>
 			<li class="breadcrumb-item">
-				<a href="/pse/cat/careerAptitudeTest.do">진로탐색</a>
+				<a href="/pse/cat/careerAptitudeTest.do">진로 탐색</a>
 			</li>
 			<li class="breadcrumb-item active">
 				<a href="/pse/cr/crl/selectCareerList.do">직업백과</a>

--- a/src/main/webapp/WEB-INF/views/pse/cr/crr/careerEncyclopediaRcmList.jsp
+++ b/src/main/webapp/WEB-INF/views/pse/cr/crr/careerEncyclopediaRcmList.jsp
@@ -2,7 +2,7 @@
 <%@ include file="/WEB-INF/views/include/header.jsp"%>
 <link rel="stylesheet" href="/css/pse/cr/crl/selectCareerList.css">
 
-<div class="breadcrumb-container-space">
+<div class="breadcrumb-container-space"  data-error-message="${errorMessage}" data-server-error="${serverError}">
 	<nav class="breadcrumb-container" aria-label="breadcrumb">
 		<ol class="breadcrumb">
 			<li class="breadcrumb-item">


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
사용자 화면 쪽 브레드크럼 추가 했습니다. 이부분은 회의를 통해 개선사항 추가해야할것같습니다. 기존에 위 섹션(페이지 이동을 시켜주는 헤더 아래부분) 제거했었으나 여러분들이 없으니 너무 허전하다해서 우선 다시 추가시켰고, 회의를 통해 변경을 할지, 유지를 할지 정해야 할것 같습니다. 

본인인증 추가하였습니다. 팀장님 사업자 번호로 등록하고, 제 카드로 결제등록은 하였습니다. 그런데 여기서 테스트버전으로도 받는 정보가 충분하여 일단은 진행하였습니다. 만약 https 환경에서 테스트버전 호환이 안된다면 실제 결제로 넘어가려고 합니다.
## 스크린샷

## 주의사항

Closes #259 
